### PR TITLE
0.20.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ mod_name=Splendid Slimes
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=LGPL
 # The mod version. See https://semver.org/
-mod_version=0.19.3
+mod_version=0.20.0
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/io/github/chakyl/splendidslimes/JEI/SlimeInfoCategory.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/JEI/SlimeInfoCategory.java
@@ -17,7 +17,6 @@ import net.minecraft.locale.Language;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.FormattedText;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.FormattedCharSequence;
 import net.minecraft.world.item.ItemStack;
 
 public class SlimeInfoCategory implements IRecipeCategory<PlortRecipe> {
@@ -61,17 +60,18 @@ public class SlimeInfoCategory implements IRecipeCategory<PlortRecipe> {
         int row = 0;
         for (int i = 0; i < recipe.inputs.size() && i < 9; i++) {
             if (i % 3 == 0) row++;
-            builder.addSlot(RecipeIngredientRole.INPUT, 193 + ((i - (row * 3)) * 18), 41 + ((18 * (i / 3)) )).addIngredients(recipe.inputs.get(i));
+            builder.addSlot(RecipeIngredientRole.INPUT, 193 + ((i - (row * 3)) * 18), 41 + ((18 * (i / 3)))).addIngredients(recipe.inputs.get(i));
         }
         builder.addSlot(RecipeIngredientRole.OUTPUT, 205, 84).addIngredient(VanillaTypes.ITEM_STACK, recipe.output);
     }
 
     @Override
     public void draw(PlortRecipe recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
-        String slimeId = recipe.slime.getTagElement("slime").getString("id").replace("splendid_slimes:", ".");
+        String[] slimeId = recipe.slime.getTagElement("slime").getString("id").split(":");
+        String translationKey = slimeId[0] + "." + slimeId[1];
         IRecipeCategory.super.draw(recipe, recipeSlotsView, guiGraphics, mouseX, mouseY);
-        guiGraphics.drawString(Minecraft.getInstance().font, Language.getInstance().getVisualOrder(Component.translatable("slime.splendid_slimes" + slimeId)), 32, 15, 0xFF4b3658, false);
-        guiGraphics.drawWordWrap(Minecraft.getInstance().font, FormattedText.of(Component.translatable("slime.splendid_slimes" + slimeId + ".info").getString()), 15, 38, 107, 0xFF4b3658);
+        guiGraphics.drawString(Minecraft.getInstance().font, Language.getInstance().getVisualOrder(Component.translatable("slime." + translationKey)), 32, 15, 0xFF4b3658, false);
+        guiGraphics.drawWordWrap(Minecraft.getInstance().font, FormattedText.of(Component.translatable("slime." + translationKey + ".info").getString()), 15, 38, 107, 0xFF4b3658);
         guiGraphics.drawString(Minecraft.getInstance().font, Language.getInstance().getVisualOrder(Component.translatable("jei.splendid_slimes.category.slime_info.diet")), 134, 22, 0xFF4b3658, false);
     }
 }

--- a/src/main/java/io/github/chakyl/splendidslimes/SlimyConfig.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/SlimyConfig.java
@@ -12,7 +12,7 @@ import java.util.function.Supplier;
 
 public class SlimyConfig {
 
-    public static int slimeStarvingTime;
+    public static int slimeHungerAmount;
     public static int slimeMaxHappiness;
 
     public static int slimeHappyThreshold;
@@ -33,7 +33,7 @@ public class SlimyConfig {
         Configuration cfg = new Configuration(SplendidSlimes.MODID);
         cfg.setTitle("꒷꒦꒷꒦꒷꒦꒷꒦꒷꒦꒷꒦ Splendid Slimes Config! ꒦꒷꒦꒷꒦꒷꒦꒷꒦꒷꒦꒷");
         cfg.setComment("All entries in this config file are synced from server to client.");
-        slimeStarvingTime = cfg.getInt("Slime Starving time", "slimes", 24000, 20, Integer.MAX_VALUE, "How long it takes for Splendid Slimes to start starving, in ticks. Slimes can eat halfway through this duration");
+        slimeHungerAmount = cfg.getInt("Slime Hunger Amount", "slimes", 24000, 20, Integer.MAX_VALUE, "How much a full slime's hunger will equate to");
 
         slimeMaxHappiness = cfg.getInt("Slime Max Happiness", "slimes", 1000, 3, Integer.MAX_VALUE - 500, "Maximum happiness value for a Splendid Slime.");
         slimeHappyThreshold = cfg.getInt("Slime Happy Threshold", "slimes", 600, 0, Integer.MAX_VALUE, "Minimum amount of happiness a Splendid Slime can have before being considered 'Happy'.");
@@ -51,13 +51,13 @@ public class SlimyConfig {
         if (cfg.hasChanged()) cfg.save();
     }
 
-    static record ConfigMessage(int slimeStarvingTime, int slimeMaxHappiness, int slimeHappyThreshold,
+    static record ConfigMessage(int slimeHungerAmount, int slimeMaxHappiness, int slimeHappyThreshold,
                                 int slimeUnhappyThreshold, int slimeFuriousThreshold, int slimeEffectCooldown,
                                 boolean slimeOwnerOfflineCheck,
                                 boolean enableTarrs, int incubationTime, int plortPressingTime) {
 
         public ConfigMessage() {
-            this(SlimyConfig.slimeStarvingTime, SlimyConfig.slimeMaxHappiness, SlimyConfig.slimeHappyThreshold, SlimyConfig.slimeUnhappyThreshold, SlimyConfig.slimeFuriousThreshold, SlimyConfig.slimeEffectCooldown, SlimyConfig.slimeOwnerOfflineCheck, SlimyConfig.enableTarrs, SlimyConfig.incubationTime, SlimyConfig.plortPressingTime);
+            this(SlimyConfig.slimeHungerAmount, SlimyConfig.slimeMaxHappiness, SlimyConfig.slimeHappyThreshold, SlimyConfig.slimeUnhappyThreshold, SlimyConfig.slimeFuriousThreshold, SlimyConfig.slimeEffectCooldown, SlimyConfig.slimeOwnerOfflineCheck, SlimyConfig.enableTarrs, SlimyConfig.incubationTime, SlimyConfig.plortPressingTime);
         }
 
         public static class Provider implements MessageProvider<ConfigMessage> {
@@ -69,7 +69,7 @@ public class SlimyConfig {
 
             @Override
             public void write(ConfigMessage msg, FriendlyByteBuf buf) {
-                buf.writeInt(msg.slimeStarvingTime);
+                buf.writeInt(msg.slimeHungerAmount);
                 buf.writeInt(msg.slimeMaxHappiness);
                 buf.writeInt(msg.slimeHappyThreshold);
                 buf.writeInt(msg.slimeUnhappyThreshold);
@@ -89,7 +89,7 @@ public class SlimyConfig {
             @Override
             public void handle(ConfigMessage msg, Supplier<Context> ctx) {
                 MessageHelper.handlePacket(() -> {
-                    SlimyConfig.slimeStarvingTime = msg.slimeStarvingTime;
+                    SlimyConfig.slimeHungerAmount = msg.slimeHungerAmount;
                     SlimyConfig.slimeMaxHappiness = msg.slimeMaxHappiness;
                     SlimyConfig.slimeHappyThreshold = msg.slimeHappyThreshold;
                     SlimyConfig.slimeUnhappyThreshold = msg.slimeUnhappyThreshold;

--- a/src/main/java/io/github/chakyl/splendidslimes/SlimyConfig.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/SlimyConfig.java
@@ -23,6 +23,7 @@ public class SlimyConfig {
     public static boolean slimeOwnerOfflineCheck;
 
     public static boolean enableTarrs;
+    public static boolean enableForgivingTarrs;
 
     public static int incubationTime;
     public static int plortPressingTime;
@@ -44,6 +45,7 @@ public class SlimyConfig {
         slimeOwnerOfflineCheck = cfg.getBoolean("Slime Owner Offline Check", "slimes", true, "When true, Slimes will not get hungry or perform effects when their owner is offline. This can help prevent disasters on Multiplayer servers and has no effect in single player.");
 
         enableTarrs = cfg.getBoolean("Enable Tarrs", "slimes", true, "If true, Largo Slimes will turn into Tarrs after eating a 3rd Plort instead of just dying.");
+        enableForgivingTarrs = cfg.getBoolean("Enable Forgiving Tarrs", "slimes", false, "If true, Tarrs will be persistent and turn back into previous slime when killed");
 
         incubationTime = cfg.getInt("Slime Incubation Time", "machines", 6000, 1, Integer.MAX_VALUE, "Time it takes for Splendid Slimes to incubate in Slime Incubator");
         plortPressingTime = cfg.getInt("Plort Pressing Time", "machines", 1200, 20, Integer.MAX_VALUE - 10, "Time it takes to craft items in a Plort Press");
@@ -53,11 +55,11 @@ public class SlimyConfig {
 
     static record ConfigMessage(int slimeHungerAmount, int slimeMaxHappiness, int slimeHappyThreshold,
                                 int slimeUnhappyThreshold, int slimeFuriousThreshold, int slimeEffectCooldown,
-                                boolean slimeOwnerOfflineCheck,
-                                boolean enableTarrs, int incubationTime, int plortPressingTime) {
+                                boolean slimeOwnerOfflineCheck, boolean enableTarrs, boolean enableForgivingTarrs,
+                                int incubationTime, int plortPressingTime) {
 
         public ConfigMessage() {
-            this(SlimyConfig.slimeHungerAmount, SlimyConfig.slimeMaxHappiness, SlimyConfig.slimeHappyThreshold, SlimyConfig.slimeUnhappyThreshold, SlimyConfig.slimeFuriousThreshold, SlimyConfig.slimeEffectCooldown, SlimyConfig.slimeOwnerOfflineCheck, SlimyConfig.enableTarrs, SlimyConfig.incubationTime, SlimyConfig.plortPressingTime);
+            this(SlimyConfig.slimeHungerAmount, SlimyConfig.slimeMaxHappiness, SlimyConfig.slimeHappyThreshold, SlimyConfig.slimeUnhappyThreshold, SlimyConfig.slimeFuriousThreshold, SlimyConfig.slimeEffectCooldown, SlimyConfig.slimeOwnerOfflineCheck, SlimyConfig.enableTarrs, SlimyConfig.enableForgivingTarrs, SlimyConfig.incubationTime, SlimyConfig.plortPressingTime);
         }
 
         public static class Provider implements MessageProvider<ConfigMessage> {
@@ -77,13 +79,14 @@ public class SlimyConfig {
                 buf.writeInt(msg.slimeEffectCooldown);
                 buf.writeBoolean(msg.slimeOwnerOfflineCheck);
                 buf.writeBoolean(msg.enableTarrs);
+                buf.writeBoolean(msg.enableForgivingTarrs);
                 buf.writeInt(msg.incubationTime);
                 buf.writeInt(msg.plortPressingTime);
             }
 
             @Override
             public ConfigMessage read(FriendlyByteBuf buf) {
-                return new ConfigMessage(buf.readInt(), buf.readInt(), buf.readInt(), buf.readInt(), buf.readInt(), buf.readInt(), buf.readBoolean(), buf.readBoolean(), buf.readInt(), buf.readInt());
+                return new ConfigMessage(buf.readInt(), buf.readInt(), buf.readInt(), buf.readInt(), buf.readInt(), buf.readInt(), buf.readBoolean(), buf.readBoolean(), buf.readBoolean(), buf.readInt(), buf.readInt());
             }
 
             @Override
@@ -96,7 +99,8 @@ public class SlimyConfig {
                     SlimyConfig.slimeFuriousThreshold = msg.slimeFuriousThreshold;
                     SlimyConfig.slimeEffectCooldown = msg.slimeEffectCooldown;
                     SlimyConfig.slimeOwnerOfflineCheck = msg.slimeOwnerOfflineCheck;
-                    SlimyConfig.enableTarrs = msg.slimeOwnerOfflineCheck;
+                    SlimyConfig.enableTarrs = msg.enableTarrs;
+                    SlimyConfig.enableForgivingTarrs = msg.enableForgivingTarrs;
                     SlimyConfig.incubationTime = msg.incubationTime;
                     SlimyConfig.plortPressingTime = msg.plortPressingTime;
                 }, ctx);

--- a/src/main/java/io/github/chakyl/splendidslimes/block/SlimeIncubatorBlock.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/block/SlimeIncubatorBlock.java
@@ -1,6 +1,7 @@
 package io.github.chakyl.splendidslimes.block;
 
 import dev.shadowsoffire.placebo.block_entity.TickingEntityBlock;
+import io.github.chakyl.splendidslimes.blockentity.PlortRippitBlockEntity;
 import io.github.chakyl.splendidslimes.blockentity.SlimeIncubatorBlockEntity;
 import io.github.chakyl.splendidslimes.registry.ModElements;
 import net.minecraft.core.BlockPos;
@@ -60,20 +61,12 @@ public class SlimeIncubatorBlock extends HorizontalDirectionalBlock implements T
     public InteractionResult use(BlockState pState, Level pLevel, BlockPos pPos, Player pPlayer, InteractionHand pHand, BlockHitResult pHit) {
         if (!pLevel.isClientSide) {
             BlockEntity entity = pLevel.getBlockEntity(pPos);
-            if (pHand == InteractionHand.MAIN_HAND && entity instanceof SlimeIncubatorBlockEntity && ((SlimeIncubatorBlockEntity) entity).getProgress() == 0) {
+            if (pHand == InteractionHand.MAIN_HAND && entity instanceof SlimeIncubatorBlockEntity slimeIncubatorBlockEntity && slimeIncubatorBlockEntity.getProgress() == 0) {
                 ItemStack heldItem = pPlayer.getItemInHand(pHand);
-                if (heldItem.getItem() == ModElements.Items.SLIME_HEART.get() && heldItem.hasTag()) {
-                    CompoundTag plortTag = heldItem.getTagElement("slime");
-                    if (plortTag != null && plortTag.contains("id")){
-                        if (!pPlayer.isCreative()) heldItem.shrink(1);
-
-                        BlockState newState = pState.setValue(WORKING, true);
-                        pLevel.setBlock(pPos, newState, 2);
-
-                        pLevel.playSound(pPlayer, pPos, SoundEvents.GLOW_INK_SAC_USE, SoundSource.BLOCKS, 1.0F, 1.0F);
-                        ((SlimeIncubatorBlockEntity) entity).setSlimeType(plortTag.get("id").toString().replace("\"", ""));
-                        return InteractionResult.CONSUME;
-                    }
+                if (slimeIncubatorBlockEntity.insertItem(heldItem)) {
+                    if (!pPlayer.isCreative()) heldItem.shrink(1);
+                    pLevel.playSound(pPlayer, pPos, SoundEvents.GLOW_INK_SAC_USE, SoundSource.BLOCKS, 1.0F, 1.0F);
+                    return InteractionResult.CONSUME;
                 }
             }
             return InteractionResult.FAIL;

--- a/src/main/java/io/github/chakyl/splendidslimes/blockentity/PlortPressBlockEntity.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/blockentity/PlortPressBlockEntity.java
@@ -85,6 +85,7 @@ public class PlortPressBlockEntity extends BlockEntity implements TickingBlockEn
 
     @Override
     public void serverTick(Level level, BlockPos pos, BlockState state) {
+        if (level.hasNeighborSignal(pos)) return;
         if (level.getGameTime() % 10 == 0) {
             if (hasRecipe()) {
                 if (progress == 0) {

--- a/src/main/java/io/github/chakyl/splendidslimes/blockentity/PlortRippitBlockEntity.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/blockentity/PlortRippitBlockEntity.java
@@ -41,6 +41,7 @@ public class PlortRippitBlockEntity extends BlockEntity implements TickingBlockE
 
     @Override
     public void serverTick(Level level, BlockPos pos, BlockState state) {
+        if (level.hasNeighborSignal(pos)) return;
         if (!this.inventory.getStackInSlot(0).isEmpty() && hasRecipe()) {
             if (this.progress == 0 && !state.getValue(WORKING)) {
                 BlockState newState = state.setValue(WORKING, true);

--- a/src/main/java/io/github/chakyl/splendidslimes/blockentity/SlimeFeederBlockEntity.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/blockentity/SlimeFeederBlockEntity.java
@@ -32,7 +32,8 @@ public class SlimeFeederBlockEntity extends RandomizableContainerBlockEntity imp
 
     @Override
     public void serverTick(Level level, BlockPos pos, BlockState state) {
-        if (level.getGameTime() % 200 == 0) {
+        if (level.hasNeighborSignal(pos)) return;
+        if (level.getGameTime() % 80 == 0) {
             Boolean hasItems = false;
             for (ItemStack slotItem : contents) {
                 if (!slotItem.isEmpty()) {
@@ -53,7 +54,6 @@ public class SlimeFeederBlockEntity extends RandomizableContainerBlockEntity imp
                             boolean isPrimary = slime.isPrimaryFood(slotItem);
                             if (!handlePicky || !(slime.getPickyLastAte() == 0 && isPrimary || slime.getPickyLastAte() == 1 && !isPrimary)) {
                                 slime.handlePickup(slotItem, null);
-                                slotItem.shrink(1);
                                 break;
                             }
                         }

--- a/src/main/java/io/github/chakyl/splendidslimes/blockentity/SlimeFeederBlockEntity.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/blockentity/SlimeFeederBlockEntity.java
@@ -51,7 +51,7 @@ public class SlimeFeederBlockEntity extends RandomizableContainerBlockEntity imp
                     for (ItemStack slotItem : contents) {
                         if (slime.wantsToPickUp(slotItem)) {
                             boolean isPrimary = slime.isPrimaryFood(slotItem);
-                            if (!handlePicky || !(slime.getLastAte() == 0 && isPrimary || slime.getLastAte() == 1 && !isPrimary)) {
+                            if (!handlePicky || !(slime.getPickyLastAte() == 0 && isPrimary || slime.getPickyLastAte() == 1 && !isPrimary)) {
                                 slime.handlePickup(slotItem, null);
                                 slotItem.shrink(1);
                                 break;

--- a/src/main/java/io/github/chakyl/splendidslimes/blockentity/SlimeIncubatorBlockEntity.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/blockentity/SlimeIncubatorBlockEntity.java
@@ -8,9 +8,15 @@ import io.github.chakyl.splendidslimes.entity.SlimeEntityBase;
 import io.github.chakyl.splendidslimes.registry.ModElements;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.Connection;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientGamePacketListener;
+import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+
+import javax.annotation.Nullable;
 
 public class SlimeIncubatorBlockEntity extends BlockEntity implements TickingBlockEntity {
     private int INCUBATION_TIME = SlimyConfig.incubationTime;
@@ -35,7 +41,7 @@ public class SlimeIncubatorBlockEntity extends BlockEntity implements TickingBlo
                 BlockState newState = state.setValue(SlimeIncubatorBlock.WORKING, false);
                 level.setBlockAndUpdate(pos, newState);
                 this.slimeType = "";
-                setChanged();
+                this.setChanged();
             }
             else {
                 this.progress++;
@@ -66,8 +72,28 @@ public class SlimeIncubatorBlockEntity extends BlockEntity implements TickingBlo
         return this.slimeType;
     }
 
+    public boolean isIncubating() {
+        return !this.slimeType.isEmpty();
+    }
+
     public int getProgress() {
         return this.progress;
+    }
+
+    @Nullable
+    @Override
+    public Packet<ClientGamePacketListener> getUpdatePacket() {
+        return ClientboundBlockEntityDataPacket.create(this);
+    }
+
+    @Override
+    public CompoundTag getUpdateTag() {
+        return saveWithoutMetadata();
+    }
+
+    @Override
+    public void onDataPacket(Connection net, ClientboundBlockEntityDataPacket pkt) {
+        load(pkt.getTag());
     }
 
 }

--- a/src/main/java/io/github/chakyl/splendidslimes/blockentity/SlimeIncubatorBlockEntity.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/blockentity/SlimeIncubatorBlockEntity.java
@@ -1,27 +1,37 @@
 package io.github.chakyl.splendidslimes.blockentity;
 
 import dev.shadowsoffire.placebo.block_entity.TickingBlockEntity;
+import dev.shadowsoffire.placebo.cap.InternalItemHandler;
 import io.github.chakyl.splendidslimes.SlimyConfig;
 import io.github.chakyl.splendidslimes.block.PlortRippitBlock;
-import io.github.chakyl.splendidslimes.block.SlimeIncubatorBlock;
 import io.github.chakyl.splendidslimes.entity.SlimeEntityBase;
+import io.github.chakyl.splendidslimes.item.SlimeHeartItem;
 import io.github.chakyl.splendidslimes.registry.ModElements;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.common.util.LazyOptional;
 
 import javax.annotation.Nullable;
+
+import static io.github.chakyl.splendidslimes.block.SlimeIncubatorBlock.WORKING;
 
 public class SlimeIncubatorBlockEntity extends BlockEntity implements TickingBlockEntity {
     private int INCUBATION_TIME = SlimyConfig.incubationTime;
     protected int progress = 0;
     protected String slimeType = "";
+
+    protected final IncubatorItemHandler inventory = new IncubatorItemHandler();
 
     public SlimeIncubatorBlockEntity(BlockPos pos, BlockState state) {
         super(ModElements.BlockEntities.SLIME_INCUBATOR.get(), pos, state);
@@ -29,6 +39,7 @@ public class SlimeIncubatorBlockEntity extends BlockEntity implements TickingBlo
 
     @Override
     public void serverTick(Level level, BlockPos pos, BlockState state) {
+        if (level.hasNeighborSignal(pos)) return;
         if (!slimeType.isEmpty()) {
             if (this.progress >= INCUBATION_TIME) {
                 SlimeEntityBase birthSlime = ModElements.Entities.SPLENDID_SLIME.get().create(level);
@@ -38,16 +49,44 @@ public class SlimeIncubatorBlockEntity extends BlockEntity implements TickingBlo
                 BlockPos facingPos = pos.relative(state.getValue(PlortRippitBlock.FACING));
                 birthSlime.moveTo(facingPos.getX() + 0.25, facingPos.getY(), facingPos.getZ() + 0.25, level.random.nextFloat() * 360.0F, 0.0F);
                 level.addFreshEntity(birthSlime);
-                BlockState newState = state.setValue(SlimeIncubatorBlock.WORKING, false);
+                BlockState newState = state.setValue(WORKING, false);
                 level.setBlockAndUpdate(pos, newState);
                 this.slimeType = "";
                 this.setChanged();
-            }
-            else {
+            } else {
                 this.progress++;
             }
+        } else {
+            ItemStack stack = this.inventory.getStackInSlot(0);
+            if (!stack.isEmpty()) setIncubation(stack);
+            else this.progress = 0;
         }
-        else this.progress = 0;
+    }
+
+    public void setIncubation(ItemStack stack) {
+        if (this.getLevel() != null && !this.getLevel().isClientSide()) {
+            CompoundTag heartTag = stack.getTagElement("slime");
+            BlockState newState = this.getBlockState().setValue(WORKING, true);
+            this.getLevel().setBlock(this.getBlockPos(), newState, 2);
+            this.setSlimeType(heartTag.get("id").toString().replace("\"", ""));
+        }
+    }
+
+    public boolean insertItem(ItemStack itemStack) {
+        if (this.inventory.isItemValid(0, itemStack)) {
+            ItemStack modifiedStack = itemStack.copy();
+            modifiedStack.setCount(1);
+            this.inventory.setStackInSlot(0, modifiedStack);
+            setIncubation(itemStack);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
+        if (cap == ForgeCapabilities.ITEM_HANDLER) return LazyOptional.of(() -> this.inventory).cast();
+        return super.getCapability(cap, side);
     }
 
     @Override
@@ -96,4 +135,36 @@ public class SlimeIncubatorBlockEntity extends BlockEntity implements TickingBlo
         load(pkt.getTag());
     }
 
+    public class IncubatorItemHandler extends InternalItemHandler {
+
+        public IncubatorItemHandler() {
+            super(1);
+        }
+
+        @Override
+        public boolean isItemValid(int slot, ItemStack stack) {
+            if (this.getStackInSlot(0).isEmpty() && stack.getItem() instanceof SlimeHeartItem && stack.hasTag()) {
+                CompoundTag heartTag = stack.getTagElement("slime");
+                return heartTag != null && heartTag.contains("id");
+            }
+
+            return false;
+        }
+
+        @Override
+        public ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
+            return super.insertItem(slot, stack, simulate);
+        }
+
+        @Override
+        public ItemStack extractItem(int slot, int amount, boolean simulate) {
+            return ItemStack.EMPTY;
+        }
+
+        @Override
+        protected void onContentsChanged(int slot) {
+            SlimeIncubatorBlockEntity.this.setChanged();
+        }
+
+    }
 }

--- a/src/main/java/io/github/chakyl/splendidslimes/blockentity/SlimeSpawnerBlockEntity.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/blockentity/SlimeSpawnerBlockEntity.java
@@ -55,7 +55,7 @@ public class SlimeSpawnerBlockEntity extends BlockEntity implements TickingBlock
                 SplendidSlime spawnedSlime = (SplendidSlime) ModElements.Entities.SPLENDID_SLIME.get().create(level);
                 spawnedSlime.setSlimeBreed(slimeType);
                 spawnedSlime.setSize(2, true);
-                spawnedSlime.setEatingCooldown(SplendidSlime.SLIME_STARVING_COOLDOWN / 2);
+                spawnedSlime.setHunger(SplendidSlime.SLIME_MAX_HUNGER / 2);
                 spawnedSlime.push(d3, d4, d5);
                 spawnedSlime.moveTo(d0, d1, d2, level.random.nextFloat() * 360.0F, 0.0F);
                 level.addFreshEntity(spawnedSlime);

--- a/src/main/java/io/github/chakyl/splendidslimes/blockentity/SlimeSpawnerBlockEntity.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/blockentity/SlimeSpawnerBlockEntity.java
@@ -29,6 +29,7 @@ public class SlimeSpawnerBlockEntity extends BlockEntity implements TickingBlock
 
     @Override
     public void serverTick(Level level, BlockPos pos, BlockState state) {
+        if (level.hasNeighborSignal(pos)) return;
         if (!slimeType.isEmpty()) {
             BlockPos facingPos = pos.relative(state.getValue(DispenserBlock.FACING));
             if (level.getGameTime() % 4 == 0 && dispensedSlimes == 0 && !level.getBlockState(facingPos).isSolid() && isNearPlayer(level, pos)) {

--- a/src/main/java/io/github/chakyl/splendidslimes/blockentity/renderer/SlimeIncubatorBlockEntityRenderer.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/blockentity/renderer/SlimeIncubatorBlockEntityRenderer.java
@@ -1,0 +1,52 @@
+package io.github.chakyl.splendidslimes.blockentity.renderer;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.math.Axis;
+import io.github.chakyl.splendidslimes.blockentity.SlimeIncubatorBlockEntity;
+import io.github.chakyl.splendidslimes.entity.SlimeEntityBase;
+import io.github.chakyl.splendidslimes.registry.ModElements;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.LightTexture;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
+import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LightLayer;
+
+public class SlimeIncubatorBlockEntityRenderer implements BlockEntityRenderer<SlimeIncubatorBlockEntity> {
+    private SlimeEntityBase slimeRender = null;
+
+    public SlimeIncubatorBlockEntityRenderer(BlockEntityRendererProvider.Context context) {
+    }
+
+    @Override
+    public void render(SlimeIncubatorBlockEntity pBlockEntity, float pPartialTick, PoseStack pPoseStack, MultiBufferSource pBuffer, int pPackedLight, int pPackedOverlay) {
+        if (pBlockEntity.isIncubating()) {
+            if (slimeRender == null) {
+                slimeRender = ModElements.Entities.SPLENDID_SLIME.get().create(pBlockEntity.getLevel());
+            }
+
+            if (slimeRender != null) {
+                slimeRender.setSlimeBreed(pBlockEntity.getSlimeType());
+                pPoseStack.pushPose();
+                pPoseStack.translate(0.5, 1.1, 0.5);
+                pPoseStack.scale(0.5f, 0.5f, 0.5f);
+                float time = pBlockEntity.getLevel().getGameTime() + pPartialTick;
+                pPoseStack.mulPose(Axis.YP.rotationDegrees(time * 0.5f));
+
+                EntityRenderDispatcher dispatcher = Minecraft.getInstance().getEntityRenderDispatcher();
+                dispatcher.render(slimeRender, 0, 0, 0, 0, pPartialTick, pPoseStack, pBuffer, pPackedLight);
+                pPoseStack.popPose();
+            }
+
+        }
+    }
+
+    private int getLightLevel(Level level, BlockPos pos) {
+        int bLight = level.getBrightness(LightLayer.BLOCK, pos);
+        int sLight = level.getBrightness(LightLayer.SKY, pos);
+        return LightTexture.pack(bLight, sLight);
+    }
+}

--- a/src/main/java/io/github/chakyl/splendidslimes/client/renderer/SlimeEntityRenderer.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/client/renderer/SlimeEntityRenderer.java
@@ -6,6 +6,7 @@ import io.github.chakyl.splendidslimes.client.model.SlimeEntityModel;
 import io.github.chakyl.splendidslimes.client.model.SlimeHandyLayer;
 import io.github.chakyl.splendidslimes.client.model.SlimeHatLayer;
 import io.github.chakyl.splendidslimes.entity.SlimeEntityBase;
+import io.github.chakyl.splendidslimes.entity.Tarr;
 import net.minecraft.client.model.geom.ModelLayerLocation;
 import net.minecraft.client.renderer.ItemInHandRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -58,7 +59,7 @@ public class SlimeEntityRenderer extends MobRenderer<SlimeEntityBase, SlimeEntit
     @Override
     public ResourceLocation getTextureLocation(SlimeEntityBase slimeEntityBase) {
         String path = slimeEntityBase.getSlimeBreed().replace(":", ":textures/entity/slime/") + ".png";
-
+        if (slimeEntityBase instanceof Tarr) path = "splendid_slimes:textures/entity/slime/tarr.png";
         if (!cache.containsKey(path)) {
             cache.put(path, new ResourceLocation(path));
         }

--- a/src/main/java/io/github/chakyl/splendidslimes/client/renderer/SlimeVacRenderer.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/client/renderer/SlimeVacRenderer.java
@@ -1,0 +1,135 @@
+package io.github.chakyl.splendidslimes.client.renderer;
+
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.Tesselator;
+import com.mojang.math.Axis;
+import io.github.chakyl.splendidslimes.item.SlimeVac;
+import io.github.chakyl.splendidslimes.util.SlimeVacUtils;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.MultiBufferSource.BufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
+import net.minecraft.client.renderer.texture.TextureAtlas;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import org.joml.Matrix4f;
+
+import java.util.Map;
+
+import static io.github.chakyl.splendidslimes.util.SlimeVacUtils.*;
+
+public class SlimeVacRenderer {
+
+    private static Map<RenderType, BufferBuilder> builders = Map.of(
+            RenderType.glint(), new BufferBuilder(RenderType.glint().bufferSize()),
+            RenderType.glintDirect(), new BufferBuilder(RenderType.glintDirect().bufferSize()),
+            RenderType.glintTranslucent(), new BufferBuilder(RenderType.glintTranslucent().bufferSize()),
+            RenderType.entityGlint(), new BufferBuilder(RenderType.entityGlint().bufferSize()),
+            RenderType.entityGlintDirect(), new BufferBuilder(RenderType.entityGlintDirect().bufferSize())
+    );
+
+    public static boolean drawFirstPerson(Player player, MultiBufferSource buffer, PoseStack matrix, int light, float partialTicks) {
+        if (!SlimeVac.hasLargo(player)) return false;
+        try {
+            drawFirstPersonEntity(player, buffer, matrix, light, partialTicks);
+        } catch (Exception e) {
+        }
+
+        return true;
+    }
+
+    private static void drawFirstPersonEntity(Player player, MultiBufferSource buffer, PoseStack matrix, int light, float partialTicks) {
+        EntityRenderDispatcher manager = Minecraft.getInstance().getEntityRenderDispatcher();
+        Entity entity = getVacSlime(player);
+
+        if (entity != null) {
+            Vec3 playerpos = getExactPos(player, partialTicks);
+
+            entity.setPos(playerpos.x, playerpos.y, playerpos.z);
+            entity.xRotO = 0.0f;
+            entity.yRotO = 0.0f;
+            entity.setYHeadRot(0.0f);
+
+            float height = entity.getBbHeight();
+            float width = entity.getBbWidth();
+
+            matrix.pushPose();
+            matrix.mulPose(Axis.YP.rotationDegrees(180));
+            matrix.translate(0.0 - 0.75, -height - .01, width + 0.1);
+
+            manager.setRenderShadow(false);
+
+            if (entity instanceof LivingEntity)  ((LivingEntity) entity).hurtTime = 0;
+
+            try {
+                manager.render(entity, 0, 0, 0, 0f, 0, matrix, buffer, light);
+            } catch (Exception e) {
+            }
+            manager.setRenderShadow(true);
+            matrix.popPose();
+        }
+    }
+
+    public static void drawThirdPerson(float partialticks, Matrix4f mat) {
+        Minecraft mc = Minecraft.getInstance();
+        Level level = mc.level;
+        int light = 0;
+        int perspective = SlimeVacUtils.getPerspective();
+        EntityRenderDispatcher manager = mc.getEntityRenderDispatcher();
+
+        PoseStack matrix = new PoseStack();
+        matrix.last().pose().mul(mat);
+
+        RenderSystem.enableBlend();
+        RenderSystem.disableCull();
+        RenderSystem.disableDepthTest();
+
+        BufferSource buffer = MultiBufferSource.immediateWithBuffers(builders, Tesselator.getInstance().getBuilder());
+
+        for (Player player : level.players()) {
+            try {
+                if (perspective == 0 && player == mc.player) continue;
+
+                light = manager.getPackedLightCoords(player, partialticks);
+
+                Entity entity = SlimeVacUtils.getVacSlime(player);
+
+                if (entity != null) {
+                    applyEntityTransformations(player, partialticks, matrix, entity);
+
+                    manager.setRenderShadow(false);
+
+                    if (entity instanceof LivingEntity le) le.hurtTime = 0;
+
+                    RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+
+                    manager.render(entity, 0, 0, 0, 0f, 0, matrix, buffer, light);
+                    matrix.popPose();
+                    manager.setRenderShadow(true);
+                    matrix.popPose();
+                }
+            } catch (Exception e) {
+            }
+
+        }
+        buffer.endLastBatch();
+
+        buffer.endBatch(RenderType.entitySolid(TextureAtlas.LOCATION_BLOCKS));
+        buffer.endBatch(RenderType.entityCutout(TextureAtlas.LOCATION_BLOCKS));
+        buffer.endBatch(RenderType.entityCutoutNoCull(TextureAtlas.LOCATION_BLOCKS));
+        buffer.endBatch(RenderType.entitySmoothCutout(TextureAtlas.LOCATION_BLOCKS));
+
+        RenderSystem.enableDepthTest();
+        RenderSystem.enableCull();
+        RenderSystem.disableBlend();
+
+
+    }
+}

--- a/src/main/java/io/github/chakyl/splendidslimes/data/RavenousFood.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/data/RavenousFood.java
@@ -1,0 +1,21 @@
+package io.github.chakyl.splendidslimes.data;
+
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.item.ItemStack;
+
+public class RavenousFood {
+    private final ItemStack food;
+    private final int hungerAmount;
+
+    public RavenousFood(ItemStack food, int hungerAmount) {
+        this.food = food;
+        this.hungerAmount = hungerAmount;
+    }
+    public ItemStack getFood() {
+        return this.food;
+    }
+
+    public int getHungerAmount() {
+        return this.hungerAmount;
+    }
+}

--- a/src/main/java/io/github/chakyl/splendidslimes/data/RavenousFoods.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/data/RavenousFoods.java
@@ -1,0 +1,8 @@
+package io.github.chakyl.splendidslimes.data;
+
+import java.util.ArrayList;
+
+public class RavenousFoods extends ArrayList<RavenousFood> {
+    public RavenousFoods() {
+    }
+}

--- a/src/main/java/io/github/chakyl/splendidslimes/data/SlimeBreed.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/data/SlimeBreed.java
@@ -82,13 +82,13 @@ public record SlimeBreed(String breed, MutableComponent name,
                          List<MobEffectInstance> negativeEmitEffects,
                          List<String> positiveCommands,
                          List<String> negativeCommands,
-                         List<String> attackCommands) implements CodecProvider<SlimeBreed> {
+                         List<String> attackCommands, RavenousFoods ravenousFoods) implements CodecProvider<SlimeBreed> {
 
     public static final Codec<SlimeBreed> CODEC = new SlimeBreedCodec();
-    public static final List<String> POSSIBLE_TRAITS = Arrays.asList("aquatic", "defiant", "dominant", "recessive", "explosive", "feral", "flaming", "floating", "foodporting", "friendly", "diverse", "handy", "inverse", "largoless", "moody", "nuclear", "picky", "photosynthesizing", "putrid", "spiky", "weeping");
+    public static final List<String> POSSIBLE_TRAITS = Arrays.asList("aquatic", "defiant", "dominant", "recessive", "explosive", "feral", "flaming", "floating", "foodporting", "friendly", "diverse", "handy", "inverse", "largoless", "moody", "nuclear", "picky", "pompous", "photosynthesizing", "putrid", "ravenous", "spiky", "weeping");
 
     public SlimeBreed(SlimeBreed other) {
-        this(other.breed, other.name, other.hat, other.hatScale, other.hatXOffset, other.hatYOffset, other.hatZOffset, other.particle, other.diet, other.foods, other.favoriteFood, other.entities, other.favoriteEntity, other.hostileToEntities, other.traits, other.innateEffects, other.emitEffectParticle, other.positiveEmitEffects, other.negativeEmitEffects, other.positiveCommands, other.negativeCommands, other.attackCommands);
+        this(other.breed, other.name, other.hat, other.hatScale, other.hatXOffset, other.hatYOffset, other.hatZOffset, other.particle, other.diet, other.foods, other.favoriteFood, other.entities, other.favoriteEntity, other.hostileToEntities, other.traits, other.innateEffects, other.emitEffectParticle, other.positiveEmitEffects, other.negativeEmitEffects, other.positiveCommands, other.negativeCommands, other.attackCommands, other.ravenousFoods);
     }
 
     public int getColor() {
@@ -208,6 +208,16 @@ public record SlimeBreed(String breed, MutableComponent name,
             for (String command : input.attackCommands) {
                 attackCommands.add(command);
             }
+
+            JsonArray ravenousFoods = new JsonArray();
+            for (RavenousFood ravenousFood : input.ravenousFoods) {
+                JsonObject foodObj = new JsonObject();
+                JsonElement item = ItemAdapter.ITEM_READER.toJsonTree(ravenousFood.getFood());
+                foodObj.add("item", item);
+                foodObj.addProperty("hunger_amount", ravenousFood.getHungerAmount());
+                ravenousFoods.add(foodObj);
+            }
+            obj.add("ravenous_foods", ravenousFoods);
             return DataResult.success(JsonOps.INSTANCE.convertTo(ops, obj));
         }
 
@@ -253,7 +263,7 @@ public record SlimeBreed(String breed, MutableComponent name,
             if (obj.has("foods")) {
                 JsonArray parsedFood = GsonHelper.getAsJsonArray(obj, "foods");
                 for (JsonElement e : parsedFood) {
-                    if (e.getAsJsonObject().has("item"))
+                    if (e.getAsJsonObject().has("food"))
                         foods.add(ItemAdapter.ITEM_READER.fromJson(e.getAsJsonObject(), ItemStack.class));
                     else if (e.getAsJsonObject().has("tag"))
                         foods.add(TagKey.create(Registries.ITEM, new ResourceLocation(e.getAsJsonObject().get("tag").getAsString())));
@@ -332,7 +342,19 @@ public record SlimeBreed(String breed, MutableComponent name,
                     attackCommands.add(SlimeData.parseCommand(String.valueOf(json)));
                 }
             }
-            return DataResult.success(Pair.of(new SlimeBreed(breed, name, hat, hatScale, hatXOffset, hatYOffset, hatZOffset, particle, diet, foods, favoriteFood, entities, favoriteEntity, hostileToEntitites, traits, innateEffects, emitEffectParticleType, positiveEmitEffects, negativeEmitEffects, positiveCommands, negativeCommands, attackCommands), input));
+            RavenousFoods ravenousFoods = new RavenousFoods();
+            if (obj.has("ravenous_foods")) {
+                for (JsonElement json : GsonHelper.getAsJsonArray(obj, "ravenous_foods")) {
+                    if (json.getAsJsonObject().has("food")) {
+                        ItemStack ravenItem = ItemAdapter.ITEM_READER.fromJson(json.getAsJsonObject().getAsJsonObject("food"), ItemStack.class);
+                        int food = 0;
+                        if (json.getAsJsonObject().has("hunger_amount"))
+                            food = GsonHelper.getAsInt(json.getAsJsonObject(), "hunger_amount");
+                        ravenousFoods.add(new RavenousFood(ravenItem, food));
+                    }
+                }
+            }
+            return DataResult.success(Pair.of(new SlimeBreed(breed, name, hat, hatScale, hatXOffset, hatYOffset, hatZOffset, particle, diet, foods, favoriteFood, entities, favoriteEntity, hostileToEntitites, traits, innateEffects, emitEffectParticleType, positiveEmitEffects, negativeEmitEffects, positiveCommands, negativeCommands, attackCommands, ravenousFoods), input));
         }
 
     }

--- a/src/main/java/io/github/chakyl/splendidslimes/entity/SlimeEntityBase.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/entity/SlimeEntityBase.java
@@ -68,7 +68,6 @@ public class SlimeEntityBase extends Slime {
     }
 
     public String getSlimeBreed() {
-        if (this instanceof Tarr) return SplendidSlimes.MODID + ":tarr";
         return this.entityData.get(BREED);
     }
 

--- a/src/main/java/io/github/chakyl/splendidslimes/entity/SplendidSlime.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/entity/SplendidSlime.java
@@ -23,6 +23,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.players.OldUsersConverter;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.tags.TagKey;
+import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.damagesource.DamageSource;
@@ -144,7 +145,7 @@ public class SplendidSlime extends SlimeEntityBase {
                 }
             }
             if (this.tickCount % (SLIME_EFFECT_COOLDOWN * 4) == 0 && this.hasTrait("weeping")) {
-                if (!SlimeUtils.cry(this, this.level())) {
+                if (!cry(this, this.level())) {
                     addHappiness(-50);
                 }
             }
@@ -202,27 +203,32 @@ public class SplendidSlime extends SlimeEntityBase {
         }
     }
 
-    public InteractionResult pickupSlime(Player player) {
+    public InteractionResult pickupSlime(Player player, boolean isLargo) {
         this.revive();
         if (level().isClientSide) {
             this.playSound(SoundEvents.CHICKEN_EGG, 1.0F, 0.9F);
             return InteractionResult.SUCCESS;
         }
-
         CompoundTag slimeItemTags = new CompoundTag();
         CompoundTag slimeTags = new CompoundTag();
         this.save(slimeTags);
         slimeItemTags.put("entity", slimeTags);
         CompoundTag id = new CompoundTag();
         id.putString("id", this.getSlimeBreed());
-        this.playSound(SoundEvents.CHICKEN_EGG, 1.0F, 0.9F);
         slimeItemTags.put("slime", id);
-
+        if (isLargo) {
+            ItemStack handStack = player.getItemInHand(InteractionHand.MAIN_HAND);
+            CompoundTag slimeTag = new CompoundTag();
+            slimeTag.put("entity", slimeItemTags.getCompound("entity"));
+            slimeTag.put("slime", slimeItemTags.getCompound("slime"));
+            handStack.getOrCreateTag().put("largo", slimeTag);
+        }
         ItemStack slimeItem = new ItemStack(ModElements.Items.SLIME_ITEM.get());
         slimeItem.setTag(slimeItemTags);
+        this.playSound(SoundEvents.CHICKEN_EGG, 1.0F, 0.9F);
         this.discard();
 
-        if (!player.getInventory().add(slimeItem)) {
+        if (!isLargo && !player.getInventory().add(slimeItem)) {
             ItemEntity itemEntity = new ItemEntity(this.level(), this.getX(), this.getY() + 0.5, this.getZ(), slimeItem);
             itemEntity.setPickUpDelay(0);
             itemEntity.setDeltaMovement(itemEntity.getDeltaMovement().multiply(0, 1, 0));
@@ -285,7 +291,7 @@ public class SplendidSlime extends SlimeEntityBase {
             CompoundTag plortTag = pStack.getTagElement("plort");
             if (plortTag != null && plortTag.contains("id")) {
                 String id = plortTag.get("id").toString();
-                if (SlimeData.plortIsFromLargoless(id)) return false;
+                if (plortIsFromLargoless(id)) return false;
                 return !id.contains(this.getSlimeBreed()) && !(!this.getSlimeSecondaryBreed().isEmpty() && id.contains(this.getSlimeSecondaryBreed()));
             }
         }
@@ -516,8 +522,13 @@ public class SplendidSlime extends SlimeEntityBase {
 
     public void playerTouch(Player pEntity) {
         if (pEntity.isHolding(ModElements.Items.SLIME_VAC.get()) && pEntity.isCrouching()) {
-            if (SlimeVac.playerCanPickupSlime(pEntity) && this.getSlimeSecondaryBreed().isEmpty()) {
-                this.pickupSlime(pEntity);
+            if (SlimeVac.playerCanPickupSlime(pEntity)) {
+                boolean isLargo = !this.getSlimeSecondaryBreed().isEmpty();
+                if (isLargo && !SlimeVac.hasLargo(pEntity)) {
+                    this.pickupSlime(pEntity, true);
+                } else if (!isLargo) {
+                    this.pickupSlime(pEntity, false);
+                }
             }
         }
         if (this.isDealsDamage() && (this.getHappiness() <= FURIOUS_THRESHOLD || this.hasTrait("spiky") || this.hasTrait("feral"))) {
@@ -615,12 +626,18 @@ public class SplendidSlime extends SlimeEntityBase {
         this.playSound(SoundEvents.CHICKEN_EGG, 1.0F, 0.9F);
         addHappiness(happinessIncrease);
         if (hasTrait("ravenous")) {
+            boolean foundFood = false;
             for (RavenousFood ravenousFood : this.getSlime().get().ravenousFoods()) {
                 if (food.getItem().getDefaultInstance().is(ravenousFood.getFood().getItem())) {
                     setHunger(this.getHunger() + ravenousFood.getHungerAmount());
                     setDayLastAte(getDay(this.level()));
+                    foundFood = true;
                     break;
                 }
+            }
+            if (!foundFood) {
+                setHunger(this.getHunger() + Mth.floor((float) SlimyConfig.slimeHungerAmount / 4));
+                setDayLastAte(getDay(this.level()));
             }
         } else {
             setDayLastAte(getDay(this.level()));
@@ -785,8 +802,11 @@ public class SplendidSlime extends SlimeEntityBase {
                 if (victimSize > 0) victimSize--;
                 SlimeEntityBase tarr = ModElements.Entities.TARR.get().create(this.level());
                 tarr.setCustomName(component);
+                tarr.setSlimeBreed(this.getSlimeBreed());
+                tarr.setSlimeSecondaryBreed(this.getSlimeSecondaryBreed());
                 tarr.setInvulnerable(this.isInvulnerable());
                 tarr.setSize(victimSize + 1, true);
+                if (SlimyConfig.enableForgivingTarrs) tarr.setPersistenceRequired();
                 tarr.moveTo(this.getX(), this.getY() + (double) 0.5F, this.getZ(), this.random.nextFloat() * 360.0F, 0.0F);
                 this.level().addFreshEntity(tarr);
             }

--- a/src/main/java/io/github/chakyl/splendidslimes/entity/SplendidSlime.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/entity/SplendidSlime.java
@@ -2,6 +2,7 @@ package io.github.chakyl.splendidslimes.entity;
 
 import dev.shadowsoffire.placebo.reload.DynamicHolder;
 import io.github.chakyl.splendidslimes.SlimyConfig;
+import io.github.chakyl.splendidslimes.data.RavenousFood;
 import io.github.chakyl.splendidslimes.data.SlimeBreed;
 import io.github.chakyl.splendidslimes.item.SlimeInspector;
 import io.github.chakyl.splendidslimes.item.SlimeVac;
@@ -56,8 +57,10 @@ import static io.github.chakyl.splendidslimes.util.SlimeUtils.*;
 
 public class SplendidSlime extends SlimeEntityBase {
     public static final EntityDataAccessor<Integer> HAPPINESS = SynchedEntityData.defineId(SplendidSlime.class, EntityDataSerializers.INT);
-    public static final EntityDataAccessor<Integer> EATING_COOLDOWN = SynchedEntityData.defineId(SplendidSlime.class, EntityDataSerializers.INT);
-    public static final EntityDataAccessor<Integer> LAST_ATE = SynchedEntityData.defineId(SplendidSlime.class, EntityDataSerializers.INT);
+    public static final EntityDataAccessor<Integer> HUNGER = SynchedEntityData.defineId(SplendidSlime.class, EntityDataSerializers.INT);
+    public static final EntityDataAccessor<Integer> DAY_LAST_ATE = SynchedEntityData.defineId(SplendidSlime.class, EntityDataSerializers.INT);
+    public static final EntityDataAccessor<Integer> DAY_LAST_DIGESTED = SynchedEntityData.defineId(SplendidSlime.class, EntityDataSerializers.INT);
+    public static final EntityDataAccessor<Integer> PICKY_LAST_ATE = SynchedEntityData.defineId(SplendidSlime.class, EntityDataSerializers.INT);
     public static final EntityDataAccessor<String> TARGET_ENTITY = SynchedEntityData.defineId(SplendidSlime.class, EntityDataSerializers.STRING);
     public static final EntityDataAccessor<Integer> PARTICLE_ANIMATION_TICK = SynchedEntityData.defineId(SplendidSlime.class, EntityDataSerializers.INT);
     public static final EntityDataAccessor<Boolean> TAMED = SynchedEntityData.defineId(SplendidSlime.class, EntityDataSerializers.BOOLEAN);
@@ -66,8 +69,8 @@ public class SplendidSlime extends SlimeEntityBase {
     public static final String ID = "id";
     public static final String DATA = "data";
     public static final int SLIME_EFFECT_COOLDOWN = SlimyConfig.slimeEffectCooldown;
-    public static final int SLIME_STARVING_COOLDOWN = SlimyConfig.slimeStarvingTime;
-    public static final int SLIME_HUNGRY_THRESHOLD = SLIME_STARVING_COOLDOWN / 2;
+    public static final int SLIME_MAX_HUNGER = SlimyConfig.slimeHungerAmount;
+    public static final int SLIME_HUNGRY_THRESHOLD = SLIME_MAX_HUNGER / 2;
     public static final int MAX_HAPPINESS = SlimyConfig.slimeMaxHappiness;
     public static final int FURIOUS_THRESHOLD = SlimyConfig.slimeFuriousThreshold;
     public static final int UNHAPPY_THRESHOLD = SlimyConfig.slimeUnhappyThreshold;
@@ -99,9 +102,11 @@ public class SplendidSlime extends SlimeEntityBase {
         super.tick();
         if (!this.level().isClientSide) {
             int happiness = this.getHappiness();
-            int eatCooldown = this.getEatingCooldown();
-            if (eatCooldown > 0 && this.tickCount % 20 == 0 && this.isOwnerOnline()) {
-                setEatingCooldown(eatCooldown - 20);
+            int currentDay = getDay(this.level());
+            if (this.tickCount % 20 == 0 && this.isOwnerOnline() && compareDay(currentDay,this.getDayLastDigested(), 1)) {
+                int daysSinceFed = getDayOffset(currentDay, this.getDayLastAte());
+                setDayLastDigested(currentDay);
+                setHunger(this.getHunger() - (SLIME_HUNGRY_THRESHOLD * daysSinceFed));
             }
             if (this.tickCount == 2) {
                 DynamicHolder<SlimeBreed> slime = this.getSlime();
@@ -133,7 +138,7 @@ public class SplendidSlime extends SlimeEntityBase {
                         }
                     }
 
-                    if (!notHungry()) {
+                    if (isHungry()) {
                         handleHungryTraits(this);
                     }
                 }
@@ -157,7 +162,7 @@ public class SplendidSlime extends SlimeEntityBase {
                     if (SlimeComfortUtils.aquaticTraitCheck(this)) {
                         addHappiness(-10);
                     }
-                    if (this.getEatingCooldown() == 0) addHappiness(-5);
+                    if (this.getHunger() == 0) addHappiness(-5);
                 } else setHappiness(0);
             }
             int particleAnimationTick = this.getParticleAnimationTick();
@@ -235,8 +240,9 @@ public class SplendidSlime extends SlimeEntityBase {
         return true;
     }
 
-    private boolean notHungry() {
-        return getEatingCooldown() > SLIME_HUNGRY_THRESHOLD;
+    private boolean isHungry() {
+        if (hasTrait("ravenous")) return getHunger() != SLIME_MAX_HUNGER;
+        return getHunger() <= SLIME_HUNGRY_THRESHOLD;
     }
 
     public boolean checkFoods(ItemStack pStack, List<Object> foods) {
@@ -270,7 +276,7 @@ public class SplendidSlime extends SlimeEntityBase {
 
     public boolean wantsToPickUp(ItemStack pStack) {
         Item pickUpItem = pStack.getItem();
-        if (notHungry() && pickUpItem != ModElements.Items.PLORT.get()) return false;
+        if (!isHungry() && pickUpItem != ModElements.Items.PLORT.get()) return false;
         if (pickUpItem == ModElements.Items.SLIME_CANDY.get()) return true;
         if (!getSlime().isBound()) return false;
         if (pickUpItem instanceof SpawnEggItem) return false;
@@ -397,24 +403,42 @@ public class SplendidSlime extends SlimeEntityBase {
         this.entityData.set(TARGET_ENTITY, data);
     }
 
-    public int getEatingCooldown() {
-        return this.entityData.get(EATING_COOLDOWN);
+    public int getHunger() {
+        return this.entityData.get(HUNGER);
     }
 
-    public void setEatingCooldown(int data) {
-        this.entityData.set(EATING_COOLDOWN, data);
+    public void setHunger(int data) {
+        this.entityData.set(HUNGER, Math.min(SLIME_MAX_HUNGER, data));
     }
 
     public int getParticleAnimationTick() {
         return this.entityData.get(PARTICLE_ANIMATION_TICK);
     }
 
-    public int getLastAte() {
-        return this.entityData.get(LAST_ATE);
+    // This is for picky trait
+    public int getPickyLastAte() {
+        return this.entityData.get(PICKY_LAST_ATE);
     }
 
-    public void setLastAte(int data) {
-        this.entityData.set(LAST_ATE, data);
+    public void setPickyLastAte(int data) {
+        this.entityData.set(PICKY_LAST_ATE, data);
+    }
+
+    // This is for day tracking
+    public int getDayLastAte() {
+        return this.entityData.get(DAY_LAST_ATE);
+    }
+
+    public void setDayLastAte(int data) {
+        this.entityData.set(DAY_LAST_ATE, data);
+    }
+
+    public int getDayLastDigested() {
+        return this.entityData.get(DAY_LAST_DIGESTED);
+    }
+
+    public void setDayLastDigested(int data) {
+        this.entityData.set(DAY_LAST_DIGESTED, data);
     }
 
     public void setParticleAnimationTick(int data) {
@@ -466,7 +490,7 @@ public class SplendidSlime extends SlimeEntityBase {
             if (!(pEntity instanceof SplendidSlime && ((SplendidSlime) pEntity).hasTrait("flaming")))
                 pEntity.setSecondsOnFire(3);
         }
-        if (notHungry()) return;
+        if (!isHungry()) return;
         List<EntityType<? extends LivingEntity>> edibleMobs = getEdibleMobs();
         if (edibleMobs == null) return;
         for (EntityType mobType : edibleMobs) {
@@ -479,7 +503,7 @@ public class SplendidSlime extends SlimeEntityBase {
 
     @Override
     public boolean killedEntity(ServerLevel pLevel, LivingEntity pEntity) {
-        if (notHungry()) return true;
+        if (!isHungry()) return true;
         List<EntityType<? extends LivingEntity>> edibleMobs = getEdibleMobs();
         if (edibleMobs == null) return true;
         for (EntityType mobType : edibleMobs) {
@@ -527,28 +551,6 @@ public class SplendidSlime extends SlimeEntityBase {
                 this.getServer().getLevel(this.level().dimension()).sendParticles(ParticleTypes.NOTE, this.getRandomX(1.0D), this.getRandomY() + 0.5D, this.getRandomZ(1.0D), 1, d0, d1, d2, 0.2);
             }
         }
-        if (happiness > FURIOUS_THRESHOLD) {
-            ItemStack dropOne = getSlimePlort();
-            int size = this.getSize();
-            if (size >= 2) {
-                if (isFavorite) dropOne.setCount(2);
-                this.spawnAtLocation(dropOne);
-                if (!this.getSlimeSecondaryBreed().isEmpty()) {
-                    ItemStack dropTwo = getSlimePlort(true);
-                    if (isFavorite) dropTwo.setCount(2);
-                    this.spawnAtLocation(dropTwo);
-                    if (size == 2) {
-                        this.moveTo(this.getOnPos().above().getCenter());
-                        this.setJumping(false);
-                        this.setSize(size + 1, true);
-                    }
-                }
-            } else {
-                this.moveTo(this.getOnPos().above().getCenter());
-                this.setJumping(false);
-                this.setSize(size + 1, true);
-            }
-        }
         if (!this.getTamed()) {
             Player closestPlayer = null;
             List<Player> nearbyPlayers = this.level().getEntitiesOfClass(Player.class, this.getBoundingBox().inflate(effectRadius * 3));
@@ -592,12 +594,12 @@ public class SplendidSlime extends SlimeEntityBase {
         if (this.hasTrait("picky") && this.isLargo()) {
             if (food != null) {
                 boolean isPrimary = this.isPrimaryFood(food);
-                if (this.getLastAte() == 0 && isPrimary || this.getLastAte() == 1 && !isPrimary) {
+                if (this.getPickyLastAte() == 0 && isPrimary || this.getPickyLastAte() == 1 && !isPrimary) {
                     displayAngerParticles = true;
                     happinessIncrease = -60;
                 } else {
-                    if (this.getLastAte() == 1) this.setLastAte(0);
-                    else this.setLastAte(1);
+                    if (this.getPickyLastAte() == 1) this.setPickyLastAte(0);
+                    else this.setPickyLastAte(1);
                 }
             }
         }
@@ -612,7 +614,45 @@ public class SplendidSlime extends SlimeEntityBase {
         this.heal(2);
         this.playSound(SoundEvents.CHICKEN_EGG, 1.0F, 0.9F);
         addHappiness(happinessIncrease);
-        setEatingCooldown(SLIME_STARVING_COOLDOWN);
+        if (hasTrait("ravenous")) {
+            for (RavenousFood ravenousFood : this.getSlime().get().ravenousFoods()) {
+                if (food.getItem().getDefaultInstance().is(ravenousFood.getFood().getItem())) {
+                    setHunger(this.getHunger() + ravenousFood.getHungerAmount());
+                    setDayLastAte(getDay(this.level()));
+                    break;
+                }
+            }
+        } else {
+            setDayLastAte(getDay(this.level()));
+            setHunger(SLIME_MAX_HUNGER);
+        }
+
+        if (this.getHunger() == SLIME_MAX_HUNGER && happiness > FURIOUS_THRESHOLD) {
+            dropPlort(isFavorite);
+        }
+    }
+
+    public void dropPlort(boolean isFavorite) {
+        ItemStack dropOne = getSlimePlort();
+        int size = this.getSize();
+        if (size >= 2) {
+            if (isFavorite) dropOne.setCount(2);
+            this.spawnAtLocation(dropOne);
+            if (!this.getSlimeSecondaryBreed().isEmpty()) {
+                ItemStack dropTwo = this.getSlimePlort(true);
+                if (isFavorite) dropTwo.setCount(2);
+                this.spawnAtLocation(dropTwo);
+                if (size == 2) {
+                    this.moveTo(this.getOnPos().above().getCenter());
+                    this.setJumping(false);
+                    this.setSize(size + 1, true);
+                }
+            }
+        } else {
+            this.moveTo(this.getOnPos().above().getCenter());
+            this.setJumping(false);
+            this.setSize(size + 1, true);
+        }
     }
 
     @Nullable
@@ -661,6 +701,7 @@ public class SplendidSlime extends SlimeEntityBase {
         item.setCount(item.getCount() - 1);
         if (itemEntity != null) itemEntity.setItem(item);
     }
+
     @Override
     protected void pickUpItem(ItemEntity itemEntity) {
         ItemStack item = itemEntity.getItem();
@@ -697,7 +738,7 @@ public class SplendidSlime extends SlimeEntityBase {
             if (itemstack.getItem() instanceof SlimeInspector slimeInspector) {
                 slimeInspector.runInspection(pPlayer, this);
                 return InteractionResult.SUCCESS;
-            } else if (this.hasTrait("handy")){
+            } else if (this.hasTrait("handy")) {
                 ItemStack itemstack1 = this.equipItemIfPossible(itemstack.copy());
                 if (!itemstack1.isEmpty()) {
                     itemstack.shrink(itemstack1.getCount());
@@ -732,7 +773,7 @@ public class SplendidSlime extends SlimeEntityBase {
                         slime.setOwnerUUID(this.getOwnerUUID());
                         slime.setTamed(this.getTamed());
                         slime.setHappiness(this.getHappiness() - 100);
-                        slime.setEatingCooldown(this.getEatingCooldown());
+                        slime.setHunger(this.getHunger());
                         slime.moveTo(this.getX(), this.getY() + (double) 0.5F, this.getZ(), this.random.nextFloat() * 360.0F, 0.0F);
                         this.level().addFreshEntity(slime);
                     }
@@ -758,8 +799,10 @@ public class SplendidSlime extends SlimeEntityBase {
     protected void defineSynchedData() {
         super.defineSynchedData();
         this.entityData.define(HAPPINESS, 500);
-        this.entityData.define(LAST_ATE, 0);
-        this.entityData.define(EATING_COOLDOWN, 0);
+        this.entityData.define(PICKY_LAST_ATE, 0);
+        this.entityData.define(DAY_LAST_ATE, -1);;
+        this.entityData.define(DAY_LAST_DIGESTED, -1);
+        this.entityData.define(HUNGER, 0);
         this.entityData.define(TARGET_ENTITY, "");
         this.entityData.define(PARTICLE_ANIMATION_TICK, -1);
         this.entityData.define(TAMED, false);
@@ -771,8 +814,10 @@ public class SplendidSlime extends SlimeEntityBase {
         String secondaryBreed = nbt.getString("SecondaryBreed");
         if (this.hasTrait("largoless")) setSlimeSecondaryBreed("");
         if (!secondaryBreed.isEmpty() && plortIsFromLargoless(secondaryBreed)) setSlimeSecondaryBreed("");
-        setEatingCooldown(nbt.getInt("EatingCooldown"));
-        setLastAte(nbt.getInt("LastAte"));
+        setHunger(nbt.getInt("Hunger"));
+        setPickyLastAte(nbt.getInt("LastAte"));
+        setDayLastAte(nbt.getInt("DayLastAte"));
+        setDayLastDigested(nbt.getInt("DayLastDigested"));
         setHappiness(nbt.getInt("Happiness"));
         setTargetEntity(nbt.getString("TargetEntity"));
         setParticleAnimationTick(nbt.getInt("ParticleAnimationTick"));
@@ -797,8 +842,10 @@ public class SplendidSlime extends SlimeEntityBase {
     @Override
     public void addAdditionalSaveData(@Nonnull CompoundTag nbt) {
         super.addAdditionalSaveData(nbt);
-        nbt.putInt("EatingCooldown", this.getEatingCooldown());
-        nbt.putInt("LastAte", this.getLastAte());
+        nbt.putInt("Hunger", this.getHunger());
+        nbt.putInt("LastAte", this.getPickyLastAte());
+        nbt.putInt("DayLastAte", this.getDayLastAte());
+        nbt.putInt("DayLastDigested", this.getDayLastDigested());
         nbt.putInt("Happiness", this.getHappiness());
         nbt.putString("TargetEntity", this.getTargetEntity());
         nbt.putInt("ParticleAnimationTick", this.getParticleAnimationTick());
@@ -847,7 +894,7 @@ public class SplendidSlime extends SlimeEntityBase {
         @Override
         public boolean canContinueToUse() {
             if (!targetItem.isAlive()) targetItem = null;
-            if (this.slime.notHungry()) {
+            if (!this.slime.isHungry()) {
                 targetItem = null;
                 return false;
             }
@@ -856,7 +903,7 @@ public class SplendidSlime extends SlimeEntityBase {
 
         @Override
         public boolean canUse() {
-            if (this.slime.notHungry()) return false;
+            if (!this.slime.isHungry()) return false;
             if (this.randomInterval > 0 && this.slime.getRandom().nextInt(this.randomInterval) != 0) {
                 return false;
             } else {
@@ -898,7 +945,7 @@ public class SplendidSlime extends SlimeEntityBase {
             List<EntityType<? extends LivingEntity>> hostileToMobs = getHostileToMobs();
             if (edibleMobs == null && hostileToMobs == null) return;
             List<EntityType<? extends LivingEntity>> finalHostileToMobs = hostileToMobs;
-            List<LivingEntity> nearbyEntities = this.mob.level().getEntitiesOfClass(LivingEntity.class, this.mob.getBoundingBox().inflate(10), e -> (!notHungry() && edibleMobs.contains(e.getType())) || finalHostileToMobs.contains(e.getType()) || (hasTrait("feral") && e.getType() == EntityType.PLAYER) || (hasTrait("friendly") && e.getType() == EntityType.PLAYER) || (((SplendidSlime) this.mob).getHappiness() < FURIOUS_THRESHOLD && e.getType() == EntityType.PLAYER));
+            List<LivingEntity> nearbyEntities = this.mob.level().getEntitiesOfClass(LivingEntity.class, this.mob.getBoundingBox().inflate(10), e -> (isHungry() && edibleMobs.contains(e.getType())) || finalHostileToMobs.contains(e.getType()) || (hasTrait("feral") && e.getType() == EntityType.PLAYER) || (hasTrait("friendly") && e.getType() == EntityType.PLAYER) || (((SplendidSlime) this.mob).getHappiness() < FURIOUS_THRESHOLD && e.getType() == EntityType.PLAYER));
             if (!nearbyEntities.isEmpty()) {
                 LivingEntity targetEntity = nearbyEntities.get(0);
                 for (LivingEntity potentialTarget : nearbyEntities) {
@@ -912,7 +959,7 @@ public class SplendidSlime extends SlimeEntityBase {
         }
 
         public boolean canUse() {
-            if (notHungry() && getHostileToMobs().isEmpty()) return false;
+            if (!isHungry() && getHostileToMobs().isEmpty()) return false;
             if (this.randomInterval > 0 && this.mob.getRandom().nextInt(this.randomInterval) != 0) {
                 return false;
             } else {

--- a/src/main/java/io/github/chakyl/splendidslimes/entity/SplendidSlime.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/entity/SplendidSlime.java
@@ -636,12 +636,13 @@ public class SplendidSlime extends SlimeEntityBase {
         ItemStack dropOne = getSlimePlort();
         int size = this.getSize();
         if (size >= 2) {
-            if (isFavorite) dropOne.setCount(2);
+            boolean dropTwo = isFavorite && !hasTrait("pompous");
+            if (dropTwo) dropOne.setCount(2);
             this.spawnAtLocation(dropOne);
             if (!this.getSlimeSecondaryBreed().isEmpty()) {
-                ItemStack dropTwo = this.getSlimePlort(true);
-                if (isFavorite) dropTwo.setCount(2);
-                this.spawnAtLocation(dropTwo);
+                ItemStack secondaryDrop = this.getSlimePlort(true);
+                if (dropTwo) secondaryDrop.setCount(2);
+                this.spawnAtLocation(secondaryDrop);
                 if (size == 2) {
                     this.moveTo(this.getOnPos().above().getCenter());
                     this.setJumping(false);

--- a/src/main/java/io/github/chakyl/splendidslimes/entity/Tarr.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/entity/Tarr.java
@@ -1,6 +1,6 @@
 package io.github.chakyl.splendidslimes.entity;
 
-import io.github.chakyl.splendidslimes.SplendidSlimes;
+import io.github.chakyl.splendidslimes.SlimyConfig;
 import io.github.chakyl.splendidslimes.registry.ModElements;
 import net.minecraft.core.particles.ItemParticleOption;
 import net.minecraft.core.particles.ParticleOptions;
@@ -63,7 +63,29 @@ public class Tarr extends SlimeEntityBase {
     }
 
     @Override
-    public void remove(Entity.RemovalReason pReason) {
+    public void remove(RemovalReason pReason) {
+        if (!this.level().isClientSide && this.isDeadOrDying()) {
+            if (SlimyConfig.enableForgivingTarrs) {
+                Component component = this.getCustomName();
+                boolean flag = this.isNoAi();
+                SlimeEntityBase slime = ModElements.Entities.SPLENDID_SLIME.get().create(this.level());
+                if (slime != null) {
+                    if (this.isPersistenceRequired()) {
+                        slime.setPersistenceRequired();
+                    }
+                    String secondaryBreed = this.getSlimeSecondaryBreed();
+                    slime.setSlimeBreed(this.getSlimeBreed());
+                    if (!secondaryBreed.isEmpty()) slime.setSlimeSecondaryBreed(secondaryBreed);
+                    slime.setCustomName(component);
+                    slime.setNoAi(flag);
+                    slime.setInvulnerable(this.isInvulnerable());
+                    slime.setSize(1, true);
+                    slime.setPersistenceRequired();
+                    slime.moveTo(this.getX(), this.getY() + (double) 0.5F, this.getZ(), this.random.nextFloat() * 360.0F, 0.0F);
+                    this.level().addFreshEntity(slime);
+                }
+            }
+        }
         this.setRemoved(pReason);
         this.invalidateCaps();
         this.brain.clearMemories();

--- a/src/main/java/io/github/chakyl/splendidslimes/events/ClientForgeEvents.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/events/ClientForgeEvents.java
@@ -1,14 +1,25 @@
 package io.github.chakyl.splendidslimes.events;
 
+import com.mojang.blaze3d.vertex.PoseStack;
 import io.github.chakyl.splendidslimes.SplendidSlimes;
 import io.github.chakyl.splendidslimes.client.Keybindings;
+import io.github.chakyl.splendidslimes.client.renderer.SlimeVacRenderer;
 import io.github.chakyl.splendidslimes.network.PacketHandler;
 import io.github.chakyl.splendidslimes.network.SlimeVacModePacket;
+import io.github.chakyl.splendidslimes.registry.ModElements;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.model.HumanoidModel;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RenderHandEvent;
+import net.minecraftforge.client.event.RenderLevelStageEvent;
+import net.minecraftforge.client.event.RenderPlayerEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+
+import static io.github.chakyl.splendidslimes.util.SlimeVacUtils.getPerspective;
 
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT, modid = SplendidSlimes.MODID)
 public class ClientForgeEvents {
@@ -17,6 +28,33 @@ public class ClientForgeEvents {
         Minecraft minecraft = Minecraft.getInstance();
         if (Keybindings.INSTANCE.slimeVacModeKey.consumeClick()) {
             PacketHandler.sendToServer(new SlimeVacModePacket());
+        }
+    }
+
+
+    @SubscribeEvent
+    public static void renderHand(RenderHandEvent event) {
+        Player player = Minecraft.getInstance().player;
+        MultiBufferSource buffer = event.getMultiBufferSource();
+        PoseStack matrix = event.getPoseStack();
+        int light = event.getPackedLight();
+        float partialTicks = event.getPartialTick();
+
+        if(SlimeVacRenderer.drawFirstPerson(player, buffer, matrix, light, partialTicks) && getPerspective() == 0) event.setCanceled(true);
+    }
+
+    @SubscribeEvent
+    public static void onRenderLevel(RenderLevelStageEvent event)  {
+        if(event.getStage() == RenderLevelStageEvent.Stage.AFTER_PARTICLES)
+            SlimeVacRenderer.drawThirdPerson(event.getPartialTick(), event.getPoseStack().last().pose());
+    }
+
+    @SubscribeEvent
+    public static void onPlayerRender(RenderPlayerEvent.Pre event) {
+        Player player = event.getEntity();
+
+        if (player.getMainHandItem().getItem() == ModElements.Items.SLIME_VAC.get()) {
+            event.getRenderer().getModel().rightArmPose = HumanoidModel.ArmPose.CROSSBOW_HOLD;
         }
     }
 }

--- a/src/main/java/io/github/chakyl/splendidslimes/events/ClientModEvents.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/events/ClientModEvents.java
@@ -2,6 +2,7 @@ package io.github.chakyl.splendidslimes.events;
 
 import dev.shadowsoffire.placebo.reload.DynamicHolder;
 import io.github.chakyl.splendidslimes.SplendidSlimes;
+import io.github.chakyl.splendidslimes.blockentity.renderer.SlimeIncubatorBlockEntityRenderer;
 import io.github.chakyl.splendidslimes.client.Keybindings;
 import io.github.chakyl.splendidslimes.client.model.HatModel;
 import io.github.chakyl.splendidslimes.client.model.PlortModel;
@@ -50,7 +51,10 @@ public class ClientModEvents {
         });
 
     }
-
+    @SubscribeEvent
+    public static void registerBER(EntityRenderersEvent.RegisterRenderers event) {
+        event.registerBlockEntityRenderer(ModElements.BlockEntities.SLIME_INCUBATOR.get(), SlimeIncubatorBlockEntityRenderer::new);
+    }
     @SubscribeEvent
     public static void registerKeys(RegisterKeyMappingsEvent event) {
         event.register(Keybindings.INSTANCE.slimeVacModeKey);

--- a/src/main/java/io/github/chakyl/splendidslimes/events/ServerForgeEvents.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/events/ServerForgeEvents.java
@@ -1,14 +1,25 @@
 package io.github.chakyl.splendidslimes.events;
 
 import io.github.chakyl.splendidslimes.SplendidSlimes;
+import io.github.chakyl.splendidslimes.entity.SlimeEntityBase;
 import io.github.chakyl.splendidslimes.item.SlimeVac;
+import io.github.chakyl.splendidslimes.registry.ModElements;
 import io.github.chakyl.splendidslimes.tag.SplendidSlimesItemTags;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.animal.Chicken;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 public class ServerForgeEvents {
     @Mod.EventBusSubscriber(modid = SplendidSlimes.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
@@ -24,5 +35,45 @@ public class ServerForgeEvents {
                 }
             }
         }
+
+//        private static final Map<UUID, SlimeEntityBase> TRACKED_LARGOS = new HashMap<>();
+//
+//        @SubscribeEvent
+//        public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
+//            if (event.phase != TickEvent.Phase.END || event.player.level().isClientSide) return;
+//
+//            ServerPlayer player = (ServerPlayer) event.player;
+//            ItemStack stack = player.getMainHandItem();
+//            UUID uuid = player.getUUID();
+//
+//            if (stack.hasTag() && stack.getTag().getBoolean("RenderChicken")) {
+//                SlimeEntityBase largo = TRACKED_LARGOS.get(uuid);
+//
+//                if (largo == null || !largo.isAlive()) {
+//                    largo = ModElements.Entities.SPLENDID_SLIME.get().create(player.level());
+//                    if (largo != null) {
+//                        largo.setNoAi(true);
+//                        largo.setInvulnerable(true);
+//                        largo.setPersistenceRequired();
+//                        player.level().addFreshEntity(largo);
+//                        TRACKED_LARGOS.put(uuid, largo);
+//                    }
+//                }
+//
+//                if (largo != null) {
+//                    Vec3 look = player.getLookAngle();
+//                    double x = player.getX() + look.x * 2.0;
+//                    double y = player.getEyeY() + look.y * 2.0 - (largo.getBbHeight() / 2.0);
+//                    double z = player.getZ() + look.z * 2.0;
+//
+//                    largo.moveTo(x, y, z, player.getYRot() + 180f, player.getXRot());
+//                }
+//            } else {
+//                SlimeEntityBase largo = TRACKED_LARGOS.remove(uuid);
+//                if (largo != null) {
+//                    largo.discard();
+//                }
+//            }
+//        }
     }
 }

--- a/src/main/java/io/github/chakyl/splendidslimes/events/ServerForgeEvents.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/events/ServerForgeEvents.java
@@ -35,45 +35,5 @@ public class ServerForgeEvents {
                 }
             }
         }
-
-//        private static final Map<UUID, SlimeEntityBase> TRACKED_LARGOS = new HashMap<>();
-//
-//        @SubscribeEvent
-//        public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
-//            if (event.phase != TickEvent.Phase.END || event.player.level().isClientSide) return;
-//
-//            ServerPlayer player = (ServerPlayer) event.player;
-//            ItemStack stack = player.getMainHandItem();
-//            UUID uuid = player.getUUID();
-//
-//            if (stack.hasTag() && stack.getTag().getBoolean("RenderChicken")) {
-//                SlimeEntityBase largo = TRACKED_LARGOS.get(uuid);
-//
-//                if (largo == null || !largo.isAlive()) {
-//                    largo = ModElements.Entities.SPLENDID_SLIME.get().create(player.level());
-//                    if (largo != null) {
-//                        largo.setNoAi(true);
-//                        largo.setInvulnerable(true);
-//                        largo.setPersistenceRequired();
-//                        player.level().addFreshEntity(largo);
-//                        TRACKED_LARGOS.put(uuid, largo);
-//                    }
-//                }
-//
-//                if (largo != null) {
-//                    Vec3 look = player.getLookAngle();
-//                    double x = player.getX() + look.x * 2.0;
-//                    double y = player.getEyeY() + look.y * 2.0 - (largo.getBbHeight() / 2.0);
-//                    double z = player.getZ() + look.z * 2.0;
-//
-//                    largo.moveTo(x, y, z, player.getYRot() + 180f, player.getXRot());
-//                }
-//            } else {
-//                SlimeEntityBase largo = TRACKED_LARGOS.remove(uuid);
-//                if (largo != null) {
-//                    largo.discard();
-//                }
-//            }
-//        }
     }
 }

--- a/src/main/java/io/github/chakyl/splendidslimes/item/SlimeVac.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/item/SlimeVac.java
@@ -1,20 +1,20 @@
 package io.github.chakyl.splendidslimes.item;
 
-import com.mojang.blaze3d.shaders.Effect;
-import io.github.chakyl.splendidslimes.SplendidSlimes;
+import io.github.chakyl.splendidslimes.entity.SlimeEntityBase;
 import io.github.chakyl.splendidslimes.entity.SplendidSlime;
 import io.github.chakyl.splendidslimes.item.ItemProjectile.ItemProjectileEntity;
 import io.github.chakyl.splendidslimes.registry.ModElements;
 import io.github.chakyl.splendidslimes.tag.SplendidSlimesItemTags;
+import io.github.chakyl.splendidslimes.util.SlimeVacUtils;
 import net.minecraft.ChatFormatting;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
-import net.minecraft.world.effect.MobEffectInstance;
-import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntitySelector;
 import net.minecraft.world.entity.EntityType;
@@ -35,14 +35,11 @@ import net.minecraft.world.phys.Vec3;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 public class SlimeVac extends Item {
     public static final String NBT_MODE = "Mode";
     private static final int RANGE = 10;
-    private static final double ANGLE = Math.cos(Math.PI / 4F);//Pre-calc cosine for speed
-
-    private UUID jammedLargo = null;
+    private static final double ANGLE = Math.cos(Math.PI / 4F); //Pre-calc cosine for speed
 
     public SlimeVac(Properties pProperties) {
         super(pProperties);
@@ -107,49 +104,35 @@ public class SlimeVac extends Item {
         return getMode(stack) != VacMode.ITEM;
     }
 
-    private SplendidSlime getJammedLargo(Level level, Player player) {
-        Class entityClass = SplendidSlime.class;
-        ArrayList<Entity> entities = (ArrayList<Entity>) level.getEntitiesOfClass(entityClass, new AABB(player.getX(), player.getY(), player.getZ(), player.getX(), player.getY(), player.getZ()).inflate(2), EntitySelector.ENTITY_STILL_ALIVE);
-        if (entities.isEmpty()) {
-            this.jammedLargo = null;
-            return null;
+    public static void removeLargoTag(Player player) {
+        ItemStack stack = player.getItemInHand(InteractionHand.MAIN_HAND);
+        if (!stack.is(ModElements.Items.SLIME_VAC.get())) stack = player.getItemInHand(InteractionHand.OFF_HAND);
+        if (!stack.is(ModElements.Items.SLIME_VAC.get())) return;
+        CompoundTag tag = stack.getTag();
+        if (tag != null && tag.contains("largo")) {
+            tag.remove("largo");
         }
-        for (Entity entity : entities) {
-            if (entity.getUUID().equals(this.jammedLargo)) return (SplendidSlime) entity;
-        }
-        return null;
     }
 
-    private void moveLargo(Level level, Player player) {
-        SplendidSlime largo = this.getJammedLargo(level, player);
-        if (largo != null) {
-            player.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, 60, 1, true, false));
-            Vec3 target3 = new Vec3(player.getX(), player.getY() + player.getBbHeight() / 2, player.getZ())
-                    .add(player.getLookAngle().scale(RANGE)).add(0, 0.5, 0);
-
-
-            Vec3 entityVector = new Vec3(largo.getX(), largo.getY() + largo.getBbHeight() / 2, largo.getZ());
-            Vec3 finalVector = target3.subtract(entityVector);
-
-            if (finalVector.length() > 1) {
-                finalVector = finalVector.normalize();
-            }
-
-            largo.setDeltaMovement(finalVector.scale(0.3333333F));
-                Vec3 motVec = player.position().subtract(largo.position()).scale(0.5D);
-            largo.push(motVec.x, motVec.y + 0.2, motVec.z);
+    public static boolean hasLargo(Player player) {
+        ItemStack stack = player.getItemInHand(InteractionHand.MAIN_HAND);
+        if (!stack.is(ModElements.Items.SLIME_VAC.get())) stack = player.getItemInHand(InteractionHand.OFF_HAND);
+        if (!stack.is(ModElements.Items.SLIME_VAC.get())) return false;
+        CompoundTag tag = stack.getTag();
+        if (tag != null && tag.contains("largo")) {
+            return !tag.getCompound("largo").isEmpty();
         }
+        return false;
     }
 
     // References: Crossroads Vacuum, Create Potato Cannon
     @Override
     public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
         ItemStack handStack = player.getItemInHand(hand);
-        if (this.jammedLargo != null) {
-            moveLargo(level, player);
-            return InteractionResultHolder.pass(handStack);
-        }
+
+        boolean hasLargo = hasLargo(player);
         if (player.isCrouching()) {
+            if (hasLargo) return InteractionResultHolder.pass(handStack);
 //            suckParticles(level, player);
             Class entityClass = SplendidSlime.class;
             if (getMode(handStack) == VacMode.ITEM) entityClass = ItemEntity.class;
@@ -166,15 +149,8 @@ public class SlimeVac extends Item {
             });
 
             for (Entity entity : entities) {
-                if (entity instanceof SplendidSlime && entity.distanceTo(player) < 2.0f) {
-                    if (this.jammedLargo == null && ((SplendidSlime) entity).isLargo()) {
-                        this.jammedLargo = entity.getUUID();
-                        entity.playSound(SoundEvents.CHICKEN_EGG, 1.0F, 0.8F);
-                    }
-                } else {
-                    Vec3 motVec = player.position().subtract(entity.position()).scale(0.25D);
-                    entity.push(motVec.x, motVec.y + 0.2, motVec.z);
-                }
+                Vec3 motVec = player.position().subtract(entity.position()).scale(0.25D);
+                entity.push(motVec.x, motVec.y + 0.1, motVec.z);
             }
 
             return InteractionResultHolder.pass(handStack);
@@ -191,15 +167,19 @@ public class SlimeVac extends Item {
                 inverseHand = InteractionHand.MAIN_HAND;
             }
 
-            ItemStack itemStackToLaunch = player.getItemInHand(inverseHand);
+            ItemStack itemStackToLaunch = findFireableItem(player);
 
             boolean slimeFired = false;
-            if (itemStackToLaunch != ItemStack.EMPTY && itemStackToLaunch.is(SplendidSlimesItemTags.SLIME_VAC_FIREABLE)) {
+            if (hasLargo || itemStackToLaunch != ItemStack.EMPTY && itemStackToLaunch.is(SplendidSlimesItemTags.SLIME_VAC_FIREABLE)) {
                 Entity projectile;
                 Item itemToLaunch = itemStackToLaunch.getItem();
                 Vec3 barrelPos = getShootLocVec(player, hand == InteractionHand.MAIN_HAND,
                         new Vec3(.45f, -0.5f, 1.0f));
-                if (itemToLaunch == ModElements.Items.SLIME_ITEM.get()) {
+                if (hasLargo) {
+                    projectile = SlimeVacUtils.getVacSlime(player);
+                    projectile.setDeltaMovement(0, 0, 0);
+                    slimeFired = true;
+                } else if (itemToLaunch == ModElements.Items.SLIME_ITEM.get()) {
                     projectile = SlimeInventoryItem.getSlimeFromItem(itemStackToLaunch.getTag().getCompound("entity"), itemStackToLaunch.getTag().getCompound("slime"), level);
                     projectile.setDeltaMovement(0, 0, 0);
                     slimeFired = true;
@@ -219,10 +199,22 @@ public class SlimeVac extends Item {
 
                 projectile.setPos(barrelPos.x, barrelPos.y, barrelPos.z);
                 projectile.setDeltaMovement(splitMotion);
+                if (projectile instanceof SlimeEntityBase) {
+                    BlockPos targetPos = projectile.getOnPos();
+                    while (!level.getBlockState(targetPos).isAir() && targetPos.getY() < level.getMaxBuildHeight()) {
+                        targetPos = targetPos.above();
+                    }
+                    projectile.moveTo(targetPos.getX() + 0.5D, targetPos.getY(), targetPos.getZ() + 0.5D, 0.0F, 0.0F);
+
+                }
                 level.addFreshEntity(projectile);
                 projectile.playSound(SoundEvents.CHICKEN_EGG, 1.0F, 0.9F);
-                if (slimeFired) player.setItemInHand(inverseHand, ItemStack.EMPTY);
-                else if (!player.isCreative()) player.getItemInHand(inverseHand).shrink(1);
+                if (slimeFired) {
+                    if (hasLargo) {
+                        removeLargoTag(player);
+                    } else itemStackToLaunch.shrink(1);
+                }
+                else if (!player.isCreative()) itemStackToLaunch.shrink(1);
                 player.getCooldowns().addCooldown(ModElements.Items.SLIME_VAC.get(), 4);
 
                 return InteractionResultHolder.pass(handStack);
@@ -231,24 +223,20 @@ public class SlimeVac extends Item {
         }
     }
 
-    private void leftClick(Player player) {
-        if (!player.level().isClientSide && this.jammedLargo != null) {
-            SplendidSlime largo = this.getJammedLargo(player.level(), player);
-            Vec3 lookVec = player.getLookAngle();
-            Vec3 motion = lookVec.normalize()
-                    .scale(2)
-                    .scale(1.5f);
-            Vec3 splitMotion = motion;
-            Vec3 barrelPos = getShootLocVec(player, player.getUsedItemHand() == InteractionHand.MAIN_HAND,
-                    new Vec3(.45f, -0.5f, 1.0f));
-            largo.setPos(barrelPos.x, barrelPos.y, barrelPos.z);
-            largo.setDeltaMovement(splitMotion);
+    public ItemStack findFireableItem(Player player) {
+        ItemStack fireable = ItemStack.EMPTY;
 
-            largo.playSound(SoundEvents.CHICKEN_EGG, 1.0F, 0.9F);
-            this.jammedLargo = null;
+        for (int i = 0; i < 9; i++) {
+            ItemStack stack = player.getInventory().getItem(i);
+
+            if (stack.isEmpty()) continue;
+            if (stack.is(ModElements.Items.SLIME_ITEM.get())) {
+                return stack;
+            }
+            if (fireable.isEmpty() && stack.is(SplendidSlimesItemTags.SLIME_VAC_FIREABLE)) fireable = stack;
         }
+        return fireable;
     }
-
     public static Vec3 getShootLocVec(Player player, boolean mainHand, Vec3 rightHandForward) {
         Vec3 start = player.position()
                 .add(0, player.getEyeHeight(), 0);

--- a/src/main/java/io/github/chakyl/splendidslimes/jade/SlimeIncubatorInfoComponentProvider.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/jade/SlimeIncubatorInfoComponentProvider.java
@@ -2,12 +2,14 @@ package io.github.chakyl.splendidslimes.jade;
 
 import dev.shadowsoffire.placebo.reload.DynamicHolder;
 import io.github.chakyl.splendidslimes.SlimyConfig;
+import io.github.chakyl.splendidslimes.SplendidSlimes;
 import io.github.chakyl.splendidslimes.blockentity.SlimeIncubatorBlockEntity;
 import io.github.chakyl.splendidslimes.blockentity.SlimeSpawnerBlockEntity;
 import io.github.chakyl.splendidslimes.data.SlimeBreed;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
 import snownee.jade.api.BlockAccessor;
 import snownee.jade.api.IBlockComponentProvider;
 import snownee.jade.api.IServerDataProvider;
@@ -16,7 +18,7 @@ import snownee.jade.api.config.IPluginConfig;
 
 import static io.github.chakyl.splendidslimes.util.SlimeData.getSlimeData;
 
-public enum SlimeSpawnerInfoComponentProvider implements IBlockComponentProvider, IServerDataProvider<BlockAccessor> {
+public enum SlimeIncubatorInfoComponentProvider implements IBlockComponentProvider, IServerDataProvider<BlockAccessor> {
     INSTANCE;
 
     @Override
@@ -30,26 +32,25 @@ public enum SlimeSpawnerInfoComponentProvider implements IBlockComponentProvider
             if (slime.isBound()) {
                 tooltip.add(Component.translatable("block.splendid_slimes.slime_spawner.breed", slime.get().name()));
             } else {
-                tooltip.add(Component.translatable("block.splendid_slimes.slime_spawner.breed_unset"));
+                tooltip.add(Component.translatable("block.splendid_slimes.slime_incubator.breed_unset"));
             }
         } else {
-            tooltip.add(Component.translatable("block.splendid_slimes.slime_spawner.breed_unset"));
+            tooltip.add(Component.translatable("block.splendid_slimes.slime_incubator.breed_unset"));
         }
-        if (accessor.getServerData().contains("slimeCount")) {
-            tooltip.add(Component.translatable("block.splendid_slimes.slime_spawner.slime_count", accessor.getServerData().getInt("slimeCount")));
+        if (accessor.getServerData().contains("progress")) {
+            tooltip.add(Component.translatable("block.splendid_slimes.slime_incubator.progress", Mth.floor(((float) accessor.getServerData().getInt("progress") / SlimyConfig.incubationTime) * 100) + "%"));
         }
     }
 
     @Override
     public void appendServerData(CompoundTag data, BlockAccessor accessor) {
-        SlimeSpawnerBlockEntity spawner = (SlimeSpawnerBlockEntity) accessor.getBlockEntity();
-        data.putString("slimeType", spawner.getSlimeType());
-        data.putInt("slimeCount", spawner.getSlimeCount());
+        SlimeIncubatorBlockEntity incubatorBlockEntity = (SlimeIncubatorBlockEntity) accessor.getBlockEntity();
+        data.putString("slimeType", incubatorBlockEntity.getSlimeType());
+        data.putInt("progress", incubatorBlockEntity.getProgress());
     }
 
     @Override
     public ResourceLocation getUid() {
         return SlimeInfoPlugin.UID;
     }
-
 }

--- a/src/main/java/io/github/chakyl/splendidslimes/jade/SlimeIncubatorInfoComponentProvider.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/jade/SlimeIncubatorInfoComponentProvider.java
@@ -2,9 +2,7 @@ package io.github.chakyl.splendidslimes.jade;
 
 import dev.shadowsoffire.placebo.reload.DynamicHolder;
 import io.github.chakyl.splendidslimes.SlimyConfig;
-import io.github.chakyl.splendidslimes.SplendidSlimes;
 import io.github.chakyl.splendidslimes.blockentity.SlimeIncubatorBlockEntity;
-import io.github.chakyl.splendidslimes.blockentity.SlimeSpawnerBlockEntity;
 import io.github.chakyl.splendidslimes.data.SlimeBreed;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
@@ -37,8 +35,20 @@ public enum SlimeIncubatorInfoComponentProvider implements IBlockComponentProvid
         } else {
             tooltip.add(Component.translatable("block.splendid_slimes.slime_incubator.breed_unset"));
         }
-        if (accessor.getServerData().contains("progress")) {
-            tooltip.add(Component.translatable("block.splendid_slimes.slime_incubator.progress", Mth.floor(((float) accessor.getServerData().getInt("progress") / SlimyConfig.incubationTime) * 100) + "%"));
+        if (accessor.getServerData().contains("progress") && accessor.getServerData().getInt("progress") > 0) {
+            int totalSeconds = SlimyConfig.incubationTime / 20;
+            int currentSeconds = accessor.getServerData().getInt("progress") / 20;
+            int remainingSeconds = totalSeconds - currentSeconds;
+
+            if (remainingSeconds > 0) {
+                int minutes = remainingSeconds / 60;
+                remainingSeconds %= 60;
+
+                String formattedTime = String.format("%d:%02d", minutes, remainingSeconds);
+                tooltip.add(Component.translatable("block.splendid_slimes.slime_incubator.progress", formattedTime));
+            } else {
+                tooltip.add(Component.translatable("block.splendid_slimes.slime_incubator.progress", "0:00 Seconds"));
+            }
         }
     }
 

--- a/src/main/java/io/github/chakyl/splendidslimes/jade/SlimeInfoComponentProvider.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/jade/SlimeInfoComponentProvider.java
@@ -88,12 +88,12 @@ public enum SlimeInfoComponentProvider implements IEntityComponentProvider, ISer
                 tooltip.append(Component.translatable("entity.splendid_slimes.wild").withStyle(ChatFormatting.RED));
             }
             if (tamed && entityAccessor.getPlayer().isCrouching()) {
-                PlayerInfo info = Minecraft.getInstance().getConnection().getPlayerInfo(entityAccessor.getServerData().getUUID("owner"));
+                PlayerInfo info = Minecraft.getInstance().getConnection().getPlayerInfo(entityAccessor.getServerData().getUUID("Owner"));
                 if (info != null) {
                     String name = info.getProfile().getName();
-                    tooltip.add(Component.translatable("jade.splendid_slimes.owner", name));
+                    tooltip.add(Component.translatable("entity.splendid_slimes.owner", name));
                 } else {
-                    tooltip.add(Component.translatable("jade.splendid_slimes.owner", "Unknown"));
+                    tooltip.add(Component.translatable("entity.splendid_slimes.owner", "Unknown"));
                 }
             }
         }

--- a/src/main/java/io/github/chakyl/splendidslimes/jade/SlimeInfoComponentProvider.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/jade/SlimeInfoComponentProvider.java
@@ -51,10 +51,10 @@ public enum SlimeInfoComponentProvider implements IEntityComponentProvider, ISer
                     }
                 }
             }
-            if (entityAccessor.getServerData().contains("EatingCooldown")) {
-                int eatingCooldown = entityAccessor.getServerData().getInt("EatingCooldown");
-                int maxEatingCooldown = SlimyConfig.slimeStarvingTime;
-                int hunger = (int) Math.round(((double) eatingCooldown / maxEatingCooldown) * 10.0);
+            if (entityAccessor.getServerData().contains("Hunger")) {
+                int eatingCooldown = entityAccessor.getServerData().getInt("Hunger");
+                int maxHunger = SlimyConfig.slimeHungerAmount;
+                int hunger = (int) Math.round(((double) eatingCooldown / maxHunger) * 10.0);
                 IElementHelper elements = IElementHelper.get();
                 ItemStack plort = ModElements.Items.PLORT.get().getDefaultInstance();
                 plort.getOrCreateTagElement("plort").putString("id", entityAccessor.getServerData().getString("Breed"));
@@ -96,7 +96,7 @@ public enum SlimeInfoComponentProvider implements IEntityComponentProvider, ISer
         data.putString("Breed", slime.getEntityData().get(SplendidSlime.BREED));
         data.putString("SecondaryBreed", slime.getEntityData().get(SplendidSlime.SECONDARY_BREED));
         data.putInt("Happiness", slime.getEntityData().get(SplendidSlime.HAPPINESS));
-        data.putInt("EatingCooldown", slime.getEntityData().get(SplendidSlime.EATING_COOLDOWN));
+        data.putInt("Hunger", slime.getEntityData().get(SplendidSlime.HUNGER));
         data.putBoolean("Tamed", slime.getEntityData().get(SplendidSlime.TAMED));
         if (((SplendidSlime) accessor.getEntity()).getTamed())
             data.putUUID("Owner", Objects.requireNonNull(slime.getEntityData().get(SplendidSlime.OWNER_UUID).orElse(null)));

--- a/src/main/java/io/github/chakyl/splendidslimes/jade/SlimeInfoComponentProvider.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/jade/SlimeInfoComponentProvider.java
@@ -6,12 +6,13 @@ import io.github.chakyl.splendidslimes.data.SlimeBreed;
 import io.github.chakyl.splendidslimes.entity.SplendidSlime;
 import io.github.chakyl.splendidslimes.registry.ModElements;
 import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.PlayerInfo;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.Vec2;
-import net.minecraftforge.common.UsernameCache;
 import snownee.jade.api.EntityAccessor;
 import snownee.jade.api.IEntityComponentProvider;
 import snownee.jade.api.IServerDataProvider;
@@ -68,7 +69,7 @@ public enum SlimeInfoComponentProvider implements IEntityComponentProvider, ISer
             if (entityAccessor.getServerData().contains("Tamed")) {
                 tamed = entityAccessor.getServerData().getBoolean("Tamed");
             }
-            if (tamed && entityAccessor.getServerData().contains("Happiness")) {
+            if (entityAccessor.getServerData().contains("Happiness")) {
                 int happiness = entityAccessor.getServerData().getInt("Happiness");
                 Component happinessComponent;
                 if (happiness >= SplendidSlime.HAPPY_THRESHOLD) {
@@ -81,11 +82,19 @@ public enum SlimeInfoComponentProvider implements IEntityComponentProvider, ISer
                     happinessComponent = Component.translatable("entity.splendid_slimes.neutral");
                 }
                 tooltip.add(happinessComponent);
-            } else {
-                tooltip.add(Component.translatable("entity.splendid_slimes.wild").withStyle(ChatFormatting.RED));
+            }
+            if (!tamed) {
+                tooltip.append(Component.literal(" | "));
+                tooltip.append(Component.translatable("entity.splendid_slimes.wild").withStyle(ChatFormatting.RED));
             }
             if (tamed && entityAccessor.getPlayer().isCrouching()) {
-                tooltip.add(Component.translatable("entity.splendid_slimes.owner", UsernameCache.getLastKnownUsername(entityAccessor.getServerData().getUUID("Owner"))));
+                PlayerInfo info = Minecraft.getInstance().getConnection().getPlayerInfo(entityAccessor.getServerData().getUUID("owner"));
+                if (info != null) {
+                    String name = info.getProfile().getName();
+                    tooltip.add(Component.translatable("jade.splendid_slimes.owner", name));
+                } else {
+                    tooltip.add(Component.translatable("jade.splendid_slimes.owner", "Unknown"));
+                }
             }
         }
     }

--- a/src/main/java/io/github/chakyl/splendidslimes/jade/SlimeInfoComponentProvider.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/jade/SlimeInfoComponentProvider.java
@@ -4,6 +4,7 @@ import dev.shadowsoffire.placebo.reload.DynamicHolder;
 import io.github.chakyl.splendidslimes.SlimyConfig;
 import io.github.chakyl.splendidslimes.data.SlimeBreed;
 import io.github.chakyl.splendidslimes.entity.SplendidSlime;
+import io.github.chakyl.splendidslimes.entity.Tarr;
 import io.github.chakyl.splendidslimes.registry.ModElements;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;

--- a/src/main/java/io/github/chakyl/splendidslimes/jade/SlimeInfoPlugin.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/jade/SlimeInfoPlugin.java
@@ -1,7 +1,9 @@
 package io.github.chakyl.splendidslimes.jade;
 
 import io.github.chakyl.splendidslimes.SplendidSlimes;
+import io.github.chakyl.splendidslimes.block.SlimeIncubatorBlock;
 import io.github.chakyl.splendidslimes.block.SlimeSpawnerBlock;
+import io.github.chakyl.splendidslimes.blockentity.SlimeIncubatorBlockEntity;
 import io.github.chakyl.splendidslimes.blockentity.SlimeSpawnerBlockEntity;
 import io.github.chakyl.splendidslimes.entity.SplendidSlime;
 import net.minecraft.resources.ResourceLocation;
@@ -16,12 +18,14 @@ public class SlimeInfoPlugin implements IWailaPlugin {
     @Override
     public void register(IWailaCommonRegistration registration) {
         registration.registerEntityDataProvider(SlimeInfoComponentProvider.INSTANCE, SplendidSlime.class);
-        registration.registerBlockDataProvider(SlimeSpawnerInfoComponentProvider.INSTANCE, SlimeSpawnerBlockEntity.class);
+        registration.registerBlockDataProvider(SlimeSpawnerInfoComponentProvider.INSTANCE, SlimeSpawnerBlockEntity.class);;
+        registration.registerBlockDataProvider(SlimeIncubatorInfoComponentProvider.INSTANCE, SlimeIncubatorBlockEntity.class);
     }
 
     @Override
     public void registerClient(IWailaClientRegistration registration) {
         registration.registerEntityComponent(SlimeInfoComponentProvider.INSTANCE, SplendidSlime.class);
         registration.registerBlockComponent(SlimeSpawnerInfoComponentProvider.INSTANCE, SlimeSpawnerBlock.class);
+        registration.registerBlockComponent(SlimeIncubatorInfoComponentProvider.INSTANCE, SlimeIncubatorBlock.class);
     }
 }

--- a/src/main/java/io/github/chakyl/splendidslimes/util/SlimeUtils.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/util/SlimeUtils.java
@@ -111,7 +111,7 @@ public class SlimeUtils {
     }
 
     public static void handleHungryTraits(SplendidSlime splendidSlime) {
-        double chance = 1 - (((splendidSlime.getEatingCooldown() + 1.0) / SplendidSlime.SLIME_HUNGRY_THRESHOLD));
+        double chance = 1 - (((splendidSlime.getHunger() + 1.0) / SplendidSlime.SLIME_HUNGRY_THRESHOLD));
         if (splendidSlime.getRandom().nextFloat() <= chance) {
             if (splendidSlime.hasTrait("explosive")) {
                 splendidSlime.level().explode(splendidSlime, splendidSlime.getX(), splendidSlime.getY(), splendidSlime.getZ(), splendidSlime.hasTrait("flaming") ? 3f : 4f, splendidSlime.hasTrait("flaming"), Level.ExplosionInteraction.NONE);
@@ -144,5 +144,17 @@ public class SlimeUtils {
         }
         slime.playSound(SoundEvents.GHAST_SCREAM, 0.6F, (float) Math.random());
         return false;
+    }
+
+    public static boolean compareDay(int day, int checkedDay, int amount) {
+        return day < checkedDay || day - checkedDay >= amount;
+    }
+    public static int getDayOffset(int day, int checkedDay) {
+        if (day < checkedDay ) return 1;
+        return day - checkedDay;
+    }
+
+    public static int getDay(Level level) {
+        return (int) (Math.floor((double) level.dayTime() / 24000) + 1);
     }
 }

--- a/src/main/java/io/github/chakyl/splendidslimes/util/SlimeVacUtils.java
+++ b/src/main/java/io/github/chakyl/splendidslimes/util/SlimeVacUtils.java
@@ -1,0 +1,171 @@
+package io.github.chakyl.splendidslimes.util;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.math.Axis;
+import io.github.chakyl.splendidslimes.item.SlimeInventoryItem;
+import io.github.chakyl.splendidslimes.item.SlimeVac;
+import net.minecraft.client.Minecraft;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.util.Mth;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Pose;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.Vec3;
+import org.joml.Quaternionf;
+
+public class SlimeVacUtils {
+
+    public static Entity getVacSlime(Player player) {
+        if (!SlimeVac.hasLargo(player)) return null;
+        CompoundTag slime = player.getItemInHand(InteractionHand.MAIN_HAND).getTag().getCompound("largo");
+        if (slime.isEmpty()) return null;
+        Entity entity = SlimeInventoryItem.getSlimeFromItem(slime.getCompound("entity"), slime.getCompound("slime"), player.level());
+
+        return entity;
+    }
+
+    @SuppressWarnings("resource")
+    public static int getPerspective() {
+        boolean isThirdPerson = !Minecraft.getInstance().options.getCameraType().isFirstPerson(); // isThirdPerson
+        boolean isThirdPersonReverse = Minecraft.getInstance().options.getCameraType().isMirrored();
+
+        if (!isThirdPerson && !isThirdPersonReverse)
+            return 0;
+        if (isThirdPerson && !isThirdPersonReverse)
+            return 1;
+        return 2;
+    }
+
+    public static void applyEntityTransformations(Player player, float partialticks, PoseStack matrix, Entity entity) {
+        int perspective = getPerspective();
+        Pose pose = player.getPose();
+
+        applyGeneralTransformations(player, partialticks, matrix);
+
+        if (perspective == 2) matrix.translate(0, -1.6, 0.65);
+        else matrix.translate(0, -1.6, -0.65);
+        matrix.scale(1.666f, 1.666f, 1.666f);
+
+        float height = entity.getBbHeight();
+        float width = entity.getBbWidth();
+        float multiplier = height * width;
+        entity.yo = 0.0f;
+        entity.yRotO = 0.0f;
+        entity.setYHeadRot(0.0f);
+        entity.xo = 0.0f;
+        entity.xRotO = 0.0f;
+
+        if (perspective == 2)
+            matrix.mulPose(Axis.YP.rotationDegrees(180));
+
+        matrix.scale((10 - multiplier) * 0.1f, (10 - multiplier) * 0.1f, (10 - multiplier) * 0.1f);
+        matrix.translate(0.0, height / 2 + -(height / 2) + 1, width - 0.1 < 0.7 ? width - 0.1 + (0.7 - (width - 0.1)) : width - 0.1);
+
+        if (pose == Pose.SWIMMING || pose == Pose.FALL_FLYING) {
+            matrix.mulPose(Axis.XN.rotationDegrees(90));
+            matrix.translate(0, -0.2 * height, 0);
+
+            if (pose == Pose.FALL_FLYING)
+                matrix.translate(0, 0, 0.2);
+        }
+
+    }
+
+    public static Vec3 getExactPos(Entity entity, float partialticks) {
+        return new Vec3(entity.xOld + (entity.getX() - entity.xOld) * partialticks, entity.yOld + (entity.getY() - entity.yOld) * partialticks, entity.zOld + (entity.getZ() - entity.zOld) * partialticks);
+    }
+
+    public static float getExactBodyRotationDegrees(LivingEntity entity, float partialticks) {
+        if (entity.getVehicle() != null && entity.getVehicle() instanceof LivingEntity vehicle)
+            if (vehicle instanceof Player player)
+                return -(player.yBodyRotO + (player.yBodyRot - player.yBodyRotO) * partialticks);
+            else
+                return -(entity.yHeadRotO + (entity.yHeadRot - entity.yHeadRotO) * partialticks);
+        else
+            return -(entity.yBodyRotO + (entity.yBodyRot - entity.yBodyRotO) * partialticks);
+    }
+
+    public static Quaternionf getExactBodyRotation(LivingEntity entity, float partialticks) {
+        return Axis.YP.rotationDegrees(getExactBodyRotationDegrees(entity, partialticks));
+    }
+
+
+    public static void applyGeneralTransformations(Player player, float partialticks, PoseStack matrix) {
+        int perspective = getPerspective();
+        Quaternionf playerrot = getExactBodyRotation(player, partialticks);
+        Vec3 playerpos = getExactPos(player, partialticks);
+        Vec3 cameraPos = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
+        Vec3 offset = playerpos.subtract(cameraPos);
+        Pose pose = player.getPose();
+
+        matrix.pushPose();
+        matrix.translate(offset.x, offset.y, offset.z);
+
+        if (perspective == 2)
+            playerrot.mul(Axis.YP.rotationDegrees(180));
+        matrix.mulPose(playerrot);
+
+        matrix.pushPose();
+        matrix.scale(0.6f, 0.6f, 0.6f);
+
+        if (perspective == 2)
+            matrix.translate(0, 0, -1.35);
+
+        if (isSneaking(player)) {
+            matrix.translate(0, -0.4, 0);
+        }
+
+        if (pose == Pose.SWIMMING) {
+            float f = player.getSwimAmount(partialticks);
+            float f3 = player.isInWater() ? -90.0F - player.xRotO : -90.0F;
+            float f4 = Mth.lerp(f, 0.0F, f3);
+            if (perspective == 2) {
+                matrix.translate(0, 0, 1.35);
+                matrix.mulPose(Axis.XP.rotationDegrees(f4));
+            } else
+                matrix.mulPose(Axis.XN.rotationDegrees(f4));
+
+            matrix.translate(0, -1.5, -1.848);
+            if (perspective == 2)
+                matrix.translate(0, 0, 2.38);
+        }
+
+        if (pose == Pose.FALL_FLYING) {
+            float f1 = player.getFallFlyingTicks() + partialticks;
+            float f2 = Mth.clamp(f1 * f1 / 100.0F, 0.0F, 1.0F);
+            if (!player.isAutoSpinAttack()) {
+                if (perspective == 2)
+                    matrix.translate(0, 0, 1.35);
+
+                if (perspective == 2)
+                    matrix.mulPose(Axis.XP.rotationDegrees(f2 * (-90.0F - player.xRotO)));
+                else
+                    matrix.mulPose(Axis.XN.rotationDegrees(f2 * (-90.0F - player.xRotO)));
+            }
+
+            Vec3 viewVector = player.getViewVector(partialticks);
+            Vec3 deltaMovement = player.getDeltaMovement();
+            double d0 = deltaMovement.horizontalDistanceSqr();
+            double d1 = deltaMovement.horizontalDistanceSqr();
+            if (d0 > 0.0D && d1 > 0.0D) {
+                double d2 = (deltaMovement.x * viewVector.x + deltaMovement.z * viewVector.z) / (Math.sqrt(d0) * Math.sqrt(d1));
+                double d3 = deltaMovement.x * viewVector.z - deltaMovement.z * viewVector.x;
+
+                matrix.mulPose(Axis.YP.rotation((float) (Math.signum(d3) * Math.acos(d2))));
+            }
+
+            if (perspective != 2)
+                matrix.translate(0, 0, -1.35);
+            matrix.translate(0, -0.2, 0);
+        }
+
+        matrix.translate(0, 1.6, 0.65);
+    }
+
+    public static boolean isSneaking(Player player) {
+        if (player.getAbilities().flying) return false;
+        return player.isShiftKeyDown() || player.isCrouching();
+    }
+}

--- a/src/main/resources/assets/splendid_slimes/lang/en_us.json
+++ b/src/main/resources/assets/splendid_slimes/lang/en_us.json
@@ -187,6 +187,6 @@
   "jei.splendid_slimes.plort_rippit.chance": "Chance: %s",
   "jei.splendid_slimes.category.slime_traits": "Slime Traits",
   "jei.splendid_slimes.category.slime_traits.none": "Slime has no traits",
-  "block.splendid_slimes.slime_incubator.progress": "Progress: %s",
+  "block.splendid_slimes.slime_incubator.progress": "Time Left: %s",
   "block.splendid_slimes.slime_incubator.breed_unset": "Use a Slime Heart to incubate"
 }

--- a/src/main/resources/assets/splendid_slimes/lang/en_us.json
+++ b/src/main/resources/assets/splendid_slimes/lang/en_us.json
@@ -9,6 +9,8 @@
   "block.splendid_slimes.slime_spawner.breed": "Breed: %s Slime",
   "block.splendid_slimes.slime_spawner.breed_unset": "Use a Slime Spawn Egg to set the Slime Breed.",
   "block.splendid_slimes.slime_spawner.slime_count": "Spawns %s Slimes",
+  "block.splendid_slimes.slime_incubator.progress": "Time Left: %s",
+  "block.splendid_slimes.slime_incubator.breed_unset": "Use a Slime Heart to incubate",
 
   "config.jade.plugin_splendid_slimes.splendid_slime": "jade slime",
   "key.categories.splendid_slimes": "Splendid Slimes",
@@ -162,9 +164,13 @@
   "trait.splendid_slimes.diverse.name": "Diverse",
   "trait.splendid_slimes.diverse.info": "Slime will get upset if it's not in close proximity to 3 unique breeds that aren't its own.",
   "trait.splendid_slimes.pompous.name": "Pompous",
-  "trait.splendid_slimes.pompous.info": "Slime's favorite food no longer makes it drop double",
+  "trait.splendid_slimes.pompous.info": "Slime's favorite food no longer makes it drop double.",
   "trait.splendid_slimes.ravenous.name": "Ravenous",
   "trait.splendid_slimes.ravenous.info": "Will only drop plorts when its hunger bar is full. Each food in its diet feeds a different amount.",
+  "trait.splendid_slimes.wormhole.name": "Wormhole",
+  "trait.splendid_slimes.wormhole.info": "Slime will occasionally teleport nearby entities to itself when upset.",
+  "trait.splendid_slimes.necromancer.name": "Necromancer",
+  "trait.splendid_slimes.necromancer.info": "Slime summon slimy zombies when attacking. Always attacks nearby villagers.",
 
   "splendid_slimes.advancement.obtain_corral.description": "Use Corral Blocks to keep Slimes contained",
   "splendid_slimes.advancement.obtain_corral.title": "Herding Slimes",
@@ -186,7 +192,5 @@
   "jei.splendid_slimes.category.slime_incubation.incubation_time": "%ss incubation time",
   "jei.splendid_slimes.plort_rippit.chance": "Chance: %s",
   "jei.splendid_slimes.category.slime_traits": "Slime Traits",
-  "jei.splendid_slimes.category.slime_traits.none": "Slime has no traits",
-  "block.splendid_slimes.slime_incubator.progress": "Time Left: %s",
-  "block.splendid_slimes.slime_incubator.breed_unset": "Use a Slime Heart to incubate"
+  "jei.splendid_slimes.category.slime_traits.none": "Slime has no traits"
 }

--- a/src/main/resources/assets/splendid_slimes/lang/en_us.json
+++ b/src/main/resources/assets/splendid_slimes/lang/en_us.json
@@ -161,6 +161,10 @@
   "trait.splendid_slimes.friendly.info": "Slime will follow nearby players.",
   "trait.splendid_slimes.diverse.name": "Diverse",
   "trait.splendid_slimes.diverse.info": "Slime will get upset if it's not in close proximity to 3 unique breeds that aren't its own.",
+  "trait.splendid_slimes.pompous.name": "Pompous",
+  "trait.splendid_slimes.pompous.info": "Slime's favorite food no longer makes it drop double",
+  "trait.splendid_slimes.ravenous.name": "Ravenous",
+  "trait.splendid_slimes.ravenous.info": "Will only drop plorts when its hunger bar is full. Each food in its diet feeds a different amount.",
 
   "splendid_slimes.advancement.obtain_corral.description": "Use Corral Blocks to keep Slimes contained",
   "splendid_slimes.advancement.obtain_corral.title": "Herding Slimes",
@@ -182,5 +186,7 @@
   "jei.splendid_slimes.category.slime_incubation.incubation_time": "%ss incubation time",
   "jei.splendid_slimes.plort_rippit.chance": "Chance: %s",
   "jei.splendid_slimes.category.slime_traits": "Slime Traits",
-  "jei.splendid_slimes.category.slime_traits.none": "Slime has no traits"
+  "jei.splendid_slimes.category.slime_traits.none": "Slime has no traits",
+  "block.splendid_slimes.slime_incubator.progress": "Progress: %s",
+  "block.splendid_slimes.slime_incubator.breed_unset": "Use a Slime Heart to incubate"
 }

--- a/src/main/resources/assets/splendid_slimes/models/block/slime_incubator_on.json
+++ b/src/main/resources/assets/splendid_slimes/models/block/slime_incubator_on.json
@@ -1,4 +1,6 @@
 {
+	"format_version": "1.21.11",
+	"credit": "Made with Blockbench",
 	"parent": "block/block",
 	"render_type": "minecraft:translucent",
 	"textures": {
@@ -39,13 +41,13 @@
 		{
 			"name": "slime",
 			"from": [2, 12, 2],
-			"to": [14, 20, 14],
+			"to": [14, 28, 14],
 			"rotation": {"angle": 0, "axis": "y", "origin": [11, 12, 10]},
 			"faces": {
-				"north": {"uv": [6, 0, 12, 4], "texture": "#4"},
-				"east": {"uv": [6, 4, 12, 8], "texture": "#4"},
-				"south": {"uv": [6, 8, 12, 12], "texture": "#4"},
-				"west": {"uv": [0, 12, 6, 16], "texture": "#4"},
+				"north": {"uv": [6, 0, 12, 8], "texture": "#4"},
+				"east": {"uv": [6, 4, 12, 12], "texture": "#4"},
+				"south": {"uv": [6, 4, 12, 12], "texture": "#4"},
+				"west": {"uv": [0, 8, 6, 16], "texture": "#4"},
 				"up": {"uv": [6, 6, 0, 0], "texture": "#4"},
 				"down": {"uv": [6, 6, 0, 12], "texture": "#4"}
 			}
@@ -81,7 +83,7 @@
 			"scale": [0.4, 0.4, 0.4]
 		},
 		"firstperson_lefthand": {
-			"rotation": [0, 225, 0],
+			"rotation": [0, -135, 0],
 			"scale": [0.4, 0.4, 0.4]
 		},
 		"ground": {
@@ -89,7 +91,7 @@
 			"scale": [0.25, 0.25, 0.25]
 		},
 		"gui": {
-			"rotation": [30, 225, 0],
+			"rotation": [30, -135, 0],
 			"translation": [0, -2.25, 0],
 			"scale": [0.45, 0.45, 0.45]
 		},

--- a/src/main/resources/data/splendid_slimes/slimes/bony.json
+++ b/src/main/resources/data/splendid_slimes/slimes/bony.json
@@ -2,15 +2,30 @@
   "breed": "bony",
   "name": "slime.splendid_slimes.bony",
   "color": "#e8e5d2",
-  "particle": { "item": "minecraft:bone" },
+  "particle": {
+    "item": "minecraft:bone"
+  },
   "diet": "diet.splendid_slimes.bony",
   "foods": [
-    { "item": "minecraft:milk_bucket" },
-    { "tag": "forge:raw_meat" },
-    { "tag": "forge:cooked_meat" },
-    { "tag": "splendid_slimes:animal_spawn_eggs" }
+    {
+      "item": "minecraft:milk_bucket"
+    },
+    {
+      "tag": "forge:raw_meat"
+    },
+    {
+      "tag": "forge:cooked_meat"
+    },
+    {
+      "tag": "splendid_slimes:animal_spawn_eggs"
+    }
   ],
-  "favorite_food": { "item": "minecraft:milk_bucket" },
+  "traits": [
+    "ravenous"
+  ],
+  "favorite_food": {
+    "item": "minecraft:milk_bucket"
+  },
   "entities": [
     "minecraft:chicken",
     "minecraft:cow",
@@ -18,5 +33,19 @@
     "minecraft:rabbit",
     "minecraft:sheep"
   ],
-  "favorite_entity": "minecraft:sheep"
+  "favorite_entity": "minecraft:sheep",
+  "ravenous_foods": [
+    {
+      "food": {
+        "item": "minecraft:milk_bucket"
+      },
+      "hunger_amount": 500
+    },
+    {
+      "food": {
+        "item": "minecraft:chicken"
+      },
+      "hunger_amount": 200
+    }
+  ]
 }

--- a/src/main/resources/data/splendid_slimes/slimes/ender.json
+++ b/src/main/resources/data/splendid_slimes/slimes/ender.json
@@ -6,7 +6,7 @@
   "diet": "diet.splendid_slimes.ender",
   "foods": [{ "tag": "forge:gems" }],
   "favorite_food": { "item": "minecraft:amethyst_shard" },
-  "traits": ["foodporting"],
+  "traits": ["foodporting", "wormhole"],
   "negative_commands": [
     "tp @e[distance=..8] @e[limit=1,sort=nearest]",
     "playsound minecraft:entity.enderman.teleport block @a[distance=..10]"

--- a/src/main/resources/data/splendid_slimes/slimes/minty.json
+++ b/src/main/resources/data/splendid_slimes/slimes/minty.json
@@ -2,10 +2,16 @@
   "breed": "minty",
   "name": "slime.splendid_slimes.minty",
   "color": "#cd75a4",
-  "particle": { "item": "minecraft:dragon_egg" },
+  "particle": {
+    "item": "minecraft:dragon_egg"
+  },
   "hat_y_offset": -0.7,
   "diet": "diet.splendid_slimes.minty",
-  "foods": [{ "tag": "splendid_slimes:monster_spawn_eggs" }],
+  "foods": [
+    {
+      "tag": "splendid_slimes:monster_spawn_eggs"
+    }
+  ],
   "entities": [
     "minecraft:zombie",
     "minecraft:zombie_villager",
@@ -21,7 +27,13 @@
     "minecraft:cave_spider"
   ],
   "favorite_entity": "minecraft:enderman",
-  "traits": ["feral", "defiant", "floating", "putrid"],
+  "traits": [
+    "feral",
+    "defiant",
+    "floating",
+    "pompous",
+    "putrid"
+  ],
   "innate_effects": [
     {
       "effect": "minecraft:strength",

--- a/src/main/resources/data/splendid_slimes/slimes/rotting.json
+++ b/src/main/resources/data/splendid_slimes/slimes/rotting.json
@@ -16,7 +16,7 @@
     "minecraft:rabbit",
     "minecraft:sheep"
   ],
-  "traits": ["putrid"],
+  "traits": ["putrid", "necromancer"],
   "favorite_entity": "minecraft:chicken",
   "hostile_to_entities": [
     "minecraft:villager"


### PR DESCRIPTION
0.20.0
Major update! Some sneaky bugs might be present!
- Reworked hunger mechanics: Slimes will lose half their hunger at 6am every morning so they can be fed once a day 
- Added proper largo sucking and shooting with the Slime Vac
- Added ability for Slime Vac to shoot items from inventory without having to put in offhand
- Added trait: **Pompous** - Slime's favorite food no longer makes it drop double
- Added trait: **Ravenous** - Will only drop plorts when its hunger bar is full. Each food in its diet feeds a different amount.
- Added Ravenous trait to Bony slime
- Added Pompous trait to Minty slime
- Added forgiving tarrs config option that lets tarrs revive into their previous slime when killed and prevents them from despawning (default false)
- Added data field `ravenous_foods` for the ravenous trait
- Added rendering of incubating slime to Slime Incubator
- Added incubation time to Jade
- Added item capability to Slime Incubators (can insert slime hearts in via hopper)
- Added ghost traits **Wormhole** and **Necromancer** to better describe slime's command behavior
- Added ability for redstone signal to pause all machines
- Increased tick rate of Slime Feeder to 80
- Jade will now display wild status next to happiness instead of replacing it
- Fixed Owner being null on servers
- Fixed Slime feeders taking double items
- Fixed Slime info page not taking into account non-Splendid Slimes namespaces
- Fixed config syching of slime owner offline check and enable tarrs being switched
- Fixed slimes suffocating when shot out of vac in corner blocks